### PR TITLE
Silk touch on waystones

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ mod_name=signpost
 package_group=gollorum.signpost
 
 mc_version=1.19.2
-forge_version=43.0.8
+forge_version=43.1.32
 
 mod_version=2.00.5

--- a/src/generated/resources/data/signpost/loot_tables/blocks/waystone.json
+++ b/src/generated/resources/data/signpost/loot_tables/blocks/waystone.json
@@ -5,18 +5,56 @@
       "bonus_rolls": 0.0,
       "entries": [
         {
-          "type": "minecraft:item",
-          "functions": [
+          "type": "minecraft:alternatives",
+          "children": [
             {
-              "add": false,
-              "count": 1.0,
-              "function": "minecraft:set_count"
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "enchantments": [
+                      {
+                        "enchantment": "minecraft:silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "pick_waystone",
+                  "condition": "signpost:permission_check"
+                }
+              ],
+              "functions": [
+                {
+                  "function": "minecraft:copy_nbt",
+                  "ops": [
+                    {
+                      "op": "replace",
+                      "source": "Handle",
+                      "target": "Handle"
+                    },
+                    {
+                      "op": "merge",
+                      "source": "display",
+                      "target": "display"
+                    }
+                  ],
+                  "source": {
+                    "type": "signpost:waystone"
+                  }
+                }
+              ],
+              "name": "signpost:waystone"
             },
             {
-              "function": "minecraft:explosion_decay"
+              "type": "minecraft:item",
+              "name": "signpost:waystone"
             }
-          ],
-          "name": "signpost:waystone"
+          ]
         }
       ],
       "rolls": 1.0

--- a/src/generated/resources/data/signpost/loot_tables/blocks/waystone_model_aer.json
+++ b/src/generated/resources/data/signpost/loot_tables/blocks/waystone_model_aer.json
@@ -5,18 +5,56 @@
       "bonus_rolls": 0.0,
       "entries": [
         {
-          "type": "minecraft:item",
-          "functions": [
+          "type": "minecraft:alternatives",
+          "children": [
             {
-              "add": false,
-              "count": 1.0,
-              "function": "minecraft:set_count"
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "enchantments": [
+                      {
+                        "enchantment": "minecraft:silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "pick_waystone",
+                  "condition": "signpost:permission_check"
+                }
+              ],
+              "functions": [
+                {
+                  "function": "minecraft:copy_nbt",
+                  "ops": [
+                    {
+                      "op": "replace",
+                      "source": "Handle",
+                      "target": "Handle"
+                    },
+                    {
+                      "op": "merge",
+                      "source": "display",
+                      "target": "display"
+                    }
+                  ],
+                  "source": {
+                    "type": "signpost:waystone"
+                  }
+                }
+              ],
+              "name": "signpost:waystone_model_aer"
             },
             {
-              "function": "minecraft:explosion_decay"
+              "type": "minecraft:item",
+              "name": "signpost:waystone_model_aer"
             }
-          ],
-          "name": "signpost:waystone_model_aer"
+          ]
         }
       ],
       "rolls": 1.0

--- a/src/generated/resources/data/signpost/loot_tables/blocks/waystone_model_detailed_0.json
+++ b/src/generated/resources/data/signpost/loot_tables/blocks/waystone_model_detailed_0.json
@@ -5,18 +5,56 @@
       "bonus_rolls": 0.0,
       "entries": [
         {
-          "type": "minecraft:item",
-          "functions": [
+          "type": "minecraft:alternatives",
+          "children": [
             {
-              "add": false,
-              "count": 1.0,
-              "function": "minecraft:set_count"
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "enchantments": [
+                      {
+                        "enchantment": "minecraft:silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "pick_waystone",
+                  "condition": "signpost:permission_check"
+                }
+              ],
+              "functions": [
+                {
+                  "function": "minecraft:copy_nbt",
+                  "ops": [
+                    {
+                      "op": "replace",
+                      "source": "Handle",
+                      "target": "Handle"
+                    },
+                    {
+                      "op": "merge",
+                      "source": "display",
+                      "target": "display"
+                    }
+                  ],
+                  "source": {
+                    "type": "signpost:waystone"
+                  }
+                }
+              ],
+              "name": "signpost:waystone_model_detailed_0"
             },
             {
-              "function": "minecraft:explosion_decay"
+              "type": "minecraft:item",
+              "name": "signpost:waystone_model_detailed_0"
             }
-          ],
-          "name": "signpost:waystone_model_detailed_0"
+          ]
         }
       ],
       "rolls": 1.0

--- a/src/generated/resources/data/signpost/loot_tables/blocks/waystone_model_detailed_1.json
+++ b/src/generated/resources/data/signpost/loot_tables/blocks/waystone_model_detailed_1.json
@@ -5,18 +5,56 @@
       "bonus_rolls": 0.0,
       "entries": [
         {
-          "type": "minecraft:item",
-          "functions": [
+          "type": "minecraft:alternatives",
+          "children": [
             {
-              "add": false,
-              "count": 1.0,
-              "function": "minecraft:set_count"
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "enchantments": [
+                      {
+                        "enchantment": "minecraft:silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "pick_waystone",
+                  "condition": "signpost:permission_check"
+                }
+              ],
+              "functions": [
+                {
+                  "function": "minecraft:copy_nbt",
+                  "ops": [
+                    {
+                      "op": "replace",
+                      "source": "Handle",
+                      "target": "Handle"
+                    },
+                    {
+                      "op": "merge",
+                      "source": "display",
+                      "target": "display"
+                    }
+                  ],
+                  "source": {
+                    "type": "signpost:waystone"
+                  }
+                }
+              ],
+              "name": "signpost:waystone_model_detailed_1"
             },
             {
-              "function": "minecraft:explosion_decay"
+              "type": "minecraft:item",
+              "name": "signpost:waystone_model_detailed_1"
             }
-          ],
-          "name": "signpost:waystone_model_detailed_1"
+          ]
         }
       ],
       "rolls": 1.0

--- a/src/generated/resources/data/signpost/loot_tables/blocks/waystone_model_dwarf.json
+++ b/src/generated/resources/data/signpost/loot_tables/blocks/waystone_model_dwarf.json
@@ -5,18 +5,56 @@
       "bonus_rolls": 0.0,
       "entries": [
         {
-          "type": "minecraft:item",
-          "functions": [
+          "type": "minecraft:alternatives",
+          "children": [
             {
-              "add": false,
-              "count": 1.0,
-              "function": "minecraft:set_count"
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "enchantments": [
+                      {
+                        "enchantment": "minecraft:silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "pick_waystone",
+                  "condition": "signpost:permission_check"
+                }
+              ],
+              "functions": [
+                {
+                  "function": "minecraft:copy_nbt",
+                  "ops": [
+                    {
+                      "op": "replace",
+                      "source": "Handle",
+                      "target": "Handle"
+                    },
+                    {
+                      "op": "merge",
+                      "source": "display",
+                      "target": "display"
+                    }
+                  ],
+                  "source": {
+                    "type": "signpost:waystone"
+                  }
+                }
+              ],
+              "name": "signpost:waystone_model_dwarf"
             },
             {
-              "function": "minecraft:explosion_decay"
+              "type": "minecraft:item",
+              "name": "signpost:waystone_model_dwarf"
             }
-          ],
-          "name": "signpost:waystone_model_dwarf"
+          ]
         }
       ],
       "rolls": 1.0

--- a/src/generated/resources/data/signpost/loot_tables/blocks/waystone_model_simple_0.json
+++ b/src/generated/resources/data/signpost/loot_tables/blocks/waystone_model_simple_0.json
@@ -5,18 +5,56 @@
       "bonus_rolls": 0.0,
       "entries": [
         {
-          "type": "minecraft:item",
-          "functions": [
+          "type": "minecraft:alternatives",
+          "children": [
             {
-              "add": false,
-              "count": 1.0,
-              "function": "minecraft:set_count"
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "enchantments": [
+                      {
+                        "enchantment": "minecraft:silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "pick_waystone",
+                  "condition": "signpost:permission_check"
+                }
+              ],
+              "functions": [
+                {
+                  "function": "minecraft:copy_nbt",
+                  "ops": [
+                    {
+                      "op": "replace",
+                      "source": "Handle",
+                      "target": "Handle"
+                    },
+                    {
+                      "op": "merge",
+                      "source": "display",
+                      "target": "display"
+                    }
+                  ],
+                  "source": {
+                    "type": "signpost:waystone"
+                  }
+                }
+              ],
+              "name": "signpost:waystone_model_simple_0"
             },
             {
-              "function": "minecraft:explosion_decay"
+              "type": "minecraft:item",
+              "name": "signpost:waystone_model_simple_0"
             }
-          ],
-          "name": "signpost:waystone_model_simple_0"
+          ]
         }
       ],
       "rolls": 1.0

--- a/src/generated/resources/data/signpost/loot_tables/blocks/waystone_model_simple_1.json
+++ b/src/generated/resources/data/signpost/loot_tables/blocks/waystone_model_simple_1.json
@@ -5,18 +5,56 @@
       "bonus_rolls": 0.0,
       "entries": [
         {
-          "type": "minecraft:item",
-          "functions": [
+          "type": "minecraft:alternatives",
+          "children": [
             {
-              "add": false,
-              "count": 1.0,
-              "function": "minecraft:set_count"
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "enchantments": [
+                      {
+                        "enchantment": "minecraft:silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "pick_waystone",
+                  "condition": "signpost:permission_check"
+                }
+              ],
+              "functions": [
+                {
+                  "function": "minecraft:copy_nbt",
+                  "ops": [
+                    {
+                      "op": "replace",
+                      "source": "Handle",
+                      "target": "Handle"
+                    },
+                    {
+                      "op": "merge",
+                      "source": "display",
+                      "target": "display"
+                    }
+                  ],
+                  "source": {
+                    "type": "signpost:waystone"
+                  }
+                }
+              ],
+              "name": "signpost:waystone_model_simple_1"
             },
             {
-              "function": "minecraft:explosion_decay"
+              "type": "minecraft:item",
+              "name": "signpost:waystone_model_simple_1"
             }
-          ],
-          "name": "signpost:waystone_model_simple_1"
+          ]
         }
       ],
       "rolls": 1.0

--- a/src/generated/resources/data/signpost/loot_tables/blocks/waystone_model_simple_2.json
+++ b/src/generated/resources/data/signpost/loot_tables/blocks/waystone_model_simple_2.json
@@ -5,18 +5,56 @@
       "bonus_rolls": 0.0,
       "entries": [
         {
-          "type": "minecraft:item",
-          "functions": [
+          "type": "minecraft:alternatives",
+          "children": [
             {
-              "add": false,
-              "count": 1.0,
-              "function": "minecraft:set_count"
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "enchantments": [
+                      {
+                        "enchantment": "minecraft:silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "pick_waystone",
+                  "condition": "signpost:permission_check"
+                }
+              ],
+              "functions": [
+                {
+                  "function": "minecraft:copy_nbt",
+                  "ops": [
+                    {
+                      "op": "replace",
+                      "source": "Handle",
+                      "target": "Handle"
+                    },
+                    {
+                      "op": "merge",
+                      "source": "display",
+                      "target": "display"
+                    }
+                  ],
+                  "source": {
+                    "type": "signpost:waystone"
+                  }
+                }
+              ],
+              "name": "signpost:waystone_model_simple_2"
             },
             {
-              "function": "minecraft:explosion_decay"
+              "type": "minecraft:item",
+              "name": "signpost:waystone_model_simple_2"
             }
-          ],
-          "name": "signpost:waystone_model_simple_2"
+          ]
         }
       ],
       "rolls": 1.0

--- a/src/generated/resources/data/signpost/loot_tables/blocks/waystone_model_ygnar.json
+++ b/src/generated/resources/data/signpost/loot_tables/blocks/waystone_model_ygnar.json
@@ -5,18 +5,56 @@
       "bonus_rolls": 0.0,
       "entries": [
         {
-          "type": "minecraft:item",
-          "functions": [
+          "type": "minecraft:alternatives",
+          "children": [
             {
-              "add": false,
-              "count": 1.0,
-              "function": "minecraft:set_count"
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "enchantments": [
+                      {
+                        "enchantment": "minecraft:silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "pick_waystone",
+                  "condition": "signpost:permission_check"
+                }
+              ],
+              "functions": [
+                {
+                  "function": "minecraft:copy_nbt",
+                  "ops": [
+                    {
+                      "op": "replace",
+                      "source": "Handle",
+                      "target": "Handle"
+                    },
+                    {
+                      "op": "merge",
+                      "source": "display",
+                      "target": "display"
+                    }
+                  ],
+                  "source": {
+                    "type": "signpost:waystone"
+                  }
+                }
+              ],
+              "name": "signpost:waystone_model_ygnar"
             },
             {
-              "function": "minecraft:explosion_decay"
+              "type": "minecraft:item",
+              "name": "signpost:waystone_model_ygnar"
             }
-          ],
-          "name": "signpost:waystone_model_ygnar"
+          ]
         }
       ],
       "rolls": 1.0

--- a/src/generated/resources/data/signpost/recipes/cut_into_full_block.json
+++ b/src/generated/resources/data/signpost/recipes/cut_into_full_block.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:stonecutting",
+  "type": "signpost:cut_waystone",
   "count": 1,
   "ingredient": {
     "tag": "signpost:waystone"

--- a/src/main/java/gollorum/signpost/Signpost.java
+++ b/src/main/java/gollorum/signpost/Signpost.java
@@ -5,11 +5,10 @@ import gollorum.signpost.minecraft.block.tiles.PostTile;
 import gollorum.signpost.minecraft.commands.WaystoneArgument;
 import gollorum.signpost.minecraft.config.Config;
 import gollorum.signpost.minecraft.data.DataGeneration;
-import gollorum.signpost.minecraft.registry.BlockRegistry;
-import gollorum.signpost.minecraft.registry.ItemRegistry;
-import gollorum.signpost.minecraft.registry.RecipeRegistry;
-import gollorum.signpost.minecraft.registry.TileEntityRegistry;
+import gollorum.signpost.minecraft.registry.*;
 import gollorum.signpost.minecraft.rendering.PostRenderer;
+import gollorum.signpost.minecraft.storage.loot.PermissionCheck;
+import gollorum.signpost.minecraft.storage.loot.RegisteredWaystoneLootNbtProvider;
 import gollorum.signpost.minecraft.worldgen.JigsawDeserializers;
 import gollorum.signpost.minecraft.worldgen.WaystoneDiscoveryEventListener;
 import gollorum.signpost.networking.PacketHandler;
@@ -70,6 +69,9 @@ public class Signpost {
         BlockEventListener.register(forgeBus);
         WaystoneDiscoveryEventListener.register(forgeBus);
         Config.register();
+
+        NbtProviderRegistry.register(modBus);
+        LootItemConditionRegistry.register(modBus);
 
         Villages.instance.initialize();
 

--- a/src/main/java/gollorum/signpost/Teleport.java
+++ b/src/main/java/gollorum/signpost/Teleport.java
@@ -249,7 +249,7 @@ public class Teleport {
                     info.dimensionKey,
                     true,
                     info.pos,
-                    PostTile.class
+                    PostTile.getBlockEntityType()
                 ).flatMap(tile -> tile.getPart(info.identifier)
                     .flatMap(part -> part.blockPart instanceof SignBlockPart
                         ? Optional.of(new ConfirmTeleportGui.SignInfo(tile, (SignBlockPart) part.blockPart, info, part.offset)) : Optional.empty()

--- a/src/main/java/gollorum/signpost/WaystoneHandle.java
+++ b/src/main/java/gollorum/signpost/WaystoneHandle.java
@@ -14,7 +14,7 @@ import java.util.UUID;
 public interface WaystoneHandle {
 
     void write(FriendlyByteBuf buffer);
-    void write(CompoundTag compound);
+    CompoundTag write(CompoundTag compound);
 
     static Optional<WaystoneHandle> read(FriendlyByteBuf buffer) {
         String type = StringSerializer.instance.read(buffer);
@@ -60,8 +60,8 @@ public interface WaystoneHandle {
         }
 
         @Override
-        public void write(CompoundTag compound) {
-            Serializer.write(this, compound);
+        public CompoundTag write(CompoundTag compound) {
+            return Serializer.write(this, compound);
         }
 
         public static final class SerializerImpl implements CompoundSerializable<Vanilla> {

--- a/src/main/java/gollorum/signpost/WaystoneLibrary.java
+++ b/src/main/java/gollorum/signpost/WaystoneLibrary.java
@@ -1,6 +1,8 @@
 package gollorum.signpost;
 
+import gollorum.signpost.blockpartdata.types.renderers.BlockPartWaystoneUpdateListener;
 import gollorum.signpost.minecraft.block.WaystoneBlock;
+import gollorum.signpost.minecraft.block.tiles.WaystoneTile;
 import gollorum.signpost.minecraft.config.Config;
 import gollorum.signpost.minecraft.events.*;
 import gollorum.signpost.minecraft.storage.WaystoneLibraryStorage;
@@ -11,13 +13,13 @@ import gollorum.signpost.utils.*;
 import gollorum.signpost.utils.math.geometry.Vector3;
 import gollorum.signpost.utils.serialization.CompoundSerializable;
 import gollorum.signpost.utils.serialization.StringSerializer;
-import net.minecraft.Util;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.saveddata.SavedData;
 import net.minecraft.world.level.storage.DimensionDataStorage;
@@ -48,6 +50,7 @@ public class WaystoneLibrary {
 
     public static void initialize() {
         instance = new WaystoneLibrary();
+        BlockPartWaystoneUpdateListener.getInstance().initialize();
     }
 
     private final EventDispatcher.Impl.WithPublicDispatch<WaystoneUpdatedEvent> _updateEventDispatcher = new EventDispatcher.Impl.WithPublicDispatch<>();
@@ -184,10 +187,11 @@ public class WaystoneLibrary {
             }
             if(editingPlayer != null && !WaystoneData.hasSecurityPermissions(editingPlayer, location))
                 isLocked = oldEntry.isLocked;
+            for(WaystoneHandle.Vanilla oldId: oldWaystones) {
+                allWaystones.remove(oldId);
+            }
         }
-        for(WaystoneHandle.Vanilla oldId: oldWaystones) {
-            allWaystones.remove(oldId);
-        }
+        if(!validateNameDoesNotExist(newName, editingPlayer)) return Optional.empty();
         WaystoneHandle.Vanilla id = oldWaystones.length > 0 ? oldWaystones[0] : new WaystoneHandle.Vanilla(UUID.randomUUID());
         allWaystones.put(id, new WaystoneEntry(newName, location, isLocked));
         Optional<String> oldName = oldNames.length > 0 ? Optional.of(oldNames[0]) : Optional.empty();
@@ -203,6 +207,45 @@ public class WaystoneLibrary {
         markDirty();
         WaystoneBlock.discover(PlayerHandle.from(editingPlayer), new WaystoneData(id, newName, location, isLocked));
         return oldName;
+    }
+
+    public boolean tryAddNew(String newName, WaystoneLocationData location, ServerPlayer editingPlayer, Optional<WaystoneHandle.Vanilla> handle) {
+        if(handle.map(h -> !validateHandleDoesNotExist(h, editingPlayer)).orElse(false)) return false;
+        if(!validateNameDoesNotExist(newName, editingPlayer)) return false;
+        if(allWaystones.values().stream().anyMatch(entry -> entry.locationData.block.equals(location.block))) {
+            Signpost.LOGGER.error("Waystone at " + location + " (new name: " + newName +") was already present. " +
+                "This indicates invalid state.");
+            return false;
+        }
+        WaystoneHandle.Vanilla id = handle.orElseGet(() -> new WaystoneHandle.Vanilla(UUID.randomUUID()));
+        boolean isLocked = false;
+        allWaystones.put(id, new WaystoneEntry(newName, location, isLocked));
+        WaystoneUpdatedEvent updatedEvent = WaystoneUpdatedEvent.fromUpdated(
+            location,
+            newName,
+            Optional.empty(),
+            isLocked,
+            id
+        );
+        _updateEventDispatcher.dispatch(updatedEvent, false);
+        PacketHandler.sendToAll(new WaystoneUpdatedEventEvent.Packet(updatedEvent));
+        markDirty();
+        WaystoneBlock.discover(PlayerHandle.from(editingPlayer), new WaystoneData(id, newName, location, isLocked));
+        return true;
+    }
+
+    private boolean validateHandleDoesNotExist(WaystoneHandle.Vanilla handle, Player editingPlayer) {
+        if(allWaystones.containsKey(handle)) {
+            editingPlayer.sendSystemMessage(Component.translatable(LangKeys.duplicateWaystoneId));
+            return false;
+        } else return true;
+    }
+
+    private boolean validateNameDoesNotExist(String newName, Player editingPlayer) {
+        if(allWaystones.values().stream().anyMatch(entry -> entry.name.equals(newName))) {
+            editingPlayer.sendSystemMessage(Component.translatable(LangKeys.duplicateWaystoneName, newName));
+            return false;
+        } else return true;
     }
 
     public boolean remove(String name, PlayerHandle playerHandle) {
@@ -297,6 +340,18 @@ public class WaystoneLibrary {
         }
     }
 
+    public void requestWaystoneAt(WorldLocation location, Consumer<Optional<WaystoneData>> onReply, boolean isClient) {
+        if(isClient) {
+            requestedWaystoneAtLocationEventDispatcher.addListener(packet -> {
+                if(packet.waystoneLocation.equals(location)) {
+                    onReply.accept(packet.data);
+                    return true;
+                } else return false;
+            });
+            PacketHandler.sendToServer(new RequestWaystoneAtLocationEvent.Packet(location));
+        } else onReply.accept(tryGetWaystoneDataAt(location));
+    }
+
     private Optional<WaystoneHandle.Vanilla> getHandleFor(String name){
         return allWaystones.entrySet().stream()
             .filter(e -> e.getValue().name.equals(name))
@@ -356,6 +411,7 @@ public class WaystoneLibrary {
     }
 
     private Optional<WaystoneData> tryGetWaystoneDataAt(WorldLocation location) {
+        assert Signpost.getServerType().isServer;
         return getInstance().allWaystones.entrySet().stream()
             .filter(e -> e.getValue().locationData.block.equals(location))
             .findFirst()
@@ -383,7 +439,21 @@ public class WaystoneLibrary {
 
     public boolean contains(WaystoneHandle.Vanilla waystone) {
         assert Signpost.getServerType().isServer;
-        return allWaystones.containsKey(waystone);
+        if(!allWaystones.containsKey(waystone)) return false;
+        WaystoneEntry entry = allWaystones.get(waystone);
+        return assertTileEntityExists(entry);
+    }
+
+    private boolean assertTileEntityExists(WaystoneEntry entry) {
+        Optional<ServerLevel> level = TileEntityUtils.toWorld(entry.locationData.block.world, false)
+            .flatMap(lv -> lv instanceof ServerLevel ? Optional.of((ServerLevel)lv) : Optional.empty());
+        if(!level.isPresent()) return true; // Something is wrong, I cannot find the level to check.
+        Optional<WaystoneTile> entity = TileEntityUtils.findTileEntity(level.get(), entry.locationData.block.blockPos, WaystoneTile.class);
+        if(entity.isPresent()) return true;
+        else {
+            WaystoneTile.onRemoved(level.get(), entry.locationData.block.blockPos);
+            return false;
+        }
     }
 
     public void markDirty(){
@@ -500,10 +570,10 @@ public class WaystoneLibrary {
     private static final class DeliverAllWaystonesEvent implements PacketHandler.Event<DeliverAllWaystonesEvent.Packet> {
 
         public static final class Packet {
-            public final Map<WaystoneHandle.Vanilla, Tuple<String, WaystoneLocationData>> names;
+            public final Map<WaystoneHandle.Vanilla, Tuple<String, WaystoneLocationData>> data;
 
-            private Packet(Map<WaystoneHandle.Vanilla, Tuple<String, WaystoneLocationData>> names) {
-                this.names = names;
+            private Packet(Map<WaystoneHandle.Vanilla, Tuple<String, WaystoneLocationData>> data) {
+                this.data = data;
             }
         }
 
@@ -512,8 +582,8 @@ public class WaystoneLibrary {
 
         @Override
         public void encode(Packet message, FriendlyByteBuf buffer) {
-            buffer.writeInt(message.names.size());
-            for (Map.Entry<WaystoneHandle.Vanilla, Tuple<String, WaystoneLocationData>> name: message.names.entrySet()) {
+            buffer.writeInt(message.data.size());
+            for (Map.Entry<WaystoneHandle.Vanilla, Tuple<String, WaystoneLocationData>> name: message.data.entrySet()) {
                 buffer.writeUUID(name.getKey().id);
                 buffer.writeUtf(name.getValue()._1);
                 WaystoneLocationData.SERIALIZER.write(name.getValue()._2, buffer);
@@ -537,7 +607,7 @@ public class WaystoneLibrary {
 
         @Override
         public void handle(Packet message, NetworkEvent.Context context) {
-            getInstance().requestedAllWaystonesEventDispatcher.dispatch(message.names, true);
+            getInstance().requestedAllWaystonesEventDispatcher.dispatch(message.data, true);
         }
     }
 

--- a/src/main/java/gollorum/signpost/WaystoneLibrary.java
+++ b/src/main/java/gollorum/signpost/WaystoneLibrary.java
@@ -448,7 +448,7 @@ public class WaystoneLibrary {
         Optional<ServerLevel> level = TileEntityUtils.toWorld(entry.locationData.block.world, false)
             .flatMap(lv -> lv instanceof ServerLevel ? Optional.of((ServerLevel)lv) : Optional.empty());
         if(!level.isPresent()) return true; // Something is wrong, I cannot find the level to check.
-        Optional<WaystoneTile> entity = TileEntityUtils.findTileEntity(level.get(), entry.locationData.block.blockPos, WaystoneTile.class);
+        Optional<WaystoneTile> entity = level.get().getBlockEntity(entry.locationData.block.blockPos, WaystoneTile.getBlockEntityType());
         if(entity.isPresent()) return true;
         else {
             WaystoneTile.onRemoved(level.get(), entry.locationData.block.blockPos);

--- a/src/main/java/gollorum/signpost/blockpartdata/types/BlockPartRenderer.java
+++ b/src/main/java/gollorum/signpost/blockpartdata/types/BlockPartRenderer.java
@@ -1,8 +1,8 @@
-package gollorum.signpost.blockpartdata.types.renderers;
+package gollorum.signpost.blockpartdata.types;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import gollorum.signpost.Signpost;
-import gollorum.signpost.blockpartdata.types.*;
+import gollorum.signpost.blockpartdata.types.renderers.*;
 import gollorum.signpost.minecraft.gui.utils.Point;
 import gollorum.signpost.utils.BlockPart;
 import gollorum.signpost.utils.math.Angle;
@@ -14,7 +14,6 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 
 import java.util.Map;
 import java.util.Optional;
-import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 
 public abstract class BlockPartRenderer<T extends BlockPart<T>> {

--- a/src/main/java/gollorum/signpost/blockpartdata/types/LargeSignBlockPart.java
+++ b/src/main/java/gollorum/signpost/blockpartdata/types/LargeSignBlockPart.java
@@ -8,12 +8,12 @@ import gollorum.signpost.minecraft.utils.CoordinatesUtil;
 import gollorum.signpost.minecraft.utils.LangKeys;
 import gollorum.signpost.security.WithOwner;
 import gollorum.signpost.utils.BlockPartMetadata;
-import gollorum.signpost.utils.math.Angle;
+import gollorum.signpost.utils.AngleProvider;
+import gollorum.signpost.utils.NameProvider;
 import gollorum.signpost.utils.math.geometry.AABB;
 import gollorum.signpost.utils.math.geometry.Matrix4x4;
 import gollorum.signpost.utils.math.geometry.TransformedBox;
 import gollorum.signpost.utils.math.geometry.Vector3;
-import net.minecraft.Util;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
@@ -34,25 +34,25 @@ public class LargeSignBlockPart extends SignBlockPart<LargeSignBlockPart> {
         "large_sign",
         (sign, compound) -> {
             compound.put("CoreData", CoreData.SERIALIZER.write(sign.coreData));
-            compound.putString("Text0", sign.text[0]);
-            compound.putString("Text1", sign.text[1]);
-            compound.putString("Text2", sign.text[2]);
-            compound.putString("Text3", sign.text[3]);
+            compound.put("Text0", NameProvider.Serializer.write(sign.text[0]));
+            compound.put("Text1", NameProvider.Serializer.write(sign.text[1]));
+            compound.put("Text2", NameProvider.Serializer.write(sign.text[2]));
+            compound.put("Text3", NameProvider.Serializer.write(sign.text[3]));
         },
         (compound) -> new LargeSignBlockPart(
             CoreData.SERIALIZER.read(compound.getCompound("CoreData")),
-            new String[]{
-                compound.getString("Text0"),
-                compound.getString("Text1"),
-                compound.getString("Text2"),
-                compound.getString("Text3")}
+            new NameProvider[]{
+                NameProvider.fetchFrom(compound.get("Text0")),
+                NameProvider.fetchFrom(compound.get("Text1")),
+                NameProvider.fetchFrom(compound.get("Text2")),
+                NameProvider.fetchFrom(compound.get("Text3"))}
         ), LargeSignBlockPart.class);
 
-    private String[] text;
+    private NameProvider[] text;
 
     public LargeSignBlockPart(
         CoreData coreData,
-        String[] text
+        NameProvider[] text
     ) {
         super(coreData);
         assert text.length == 4;
@@ -60,8 +60,8 @@ public class LargeSignBlockPart extends SignBlockPart<LargeSignBlockPart> {
     }
 
     public LargeSignBlockPart(
-        Angle angle,
-        String[] text,
+        AngleProvider angle,
+        NameProvider[] text,
         boolean flip,
         ResourceLocation mainTexture,
         ResourceLocation secondaryTexture,
@@ -77,24 +77,29 @@ public class LargeSignBlockPart extends SignBlockPart<LargeSignBlockPart> {
         text
     ); }
 
-    public void setText(String[] text) {
+    public void setText(NameProvider[] text) {
         this.text = text;
     }
 
-    public String[] getText() { return text; }
+    public NameProvider[] getText() { return text; }
+
+    @Override
+    protected NameProvider[] getNameProviders() {
+        return text;
+    }
 
     @Override
     protected void regenerateTransformedBox() {
-        transformedBounds = new TransformedBox(LOCAL_BOUNDS).rotateAlong(Matrix4x4.Axis.Y, coreData.angle);
+        transformedBounds = new TransformedBox(LOCAL_BOUNDS).rotateAlong(Matrix4x4.Axis.Y, coreData.angleProvider.get());
         if(coreData.flip) transformedBounds = transformedBounds.scale(new Vector3(1, 1, -1));
     }
 
     private void notifyTextChanged(InteractionInfo info) {
         CompoundTag compound = new CompoundTag();
-        compound.putString("Text0", text[0]);
-        compound.putString("Text1", text[1]);
-        compound.putString("Text2", text[2]);
-        compound.putString("Text3", text[3]);
+        compound.put("Text0", NameProvider.Serializer.write(text[0]));
+        compound.put("Text1", NameProvider.Serializer.write(text[1]));
+        compound.put("Text2", NameProvider.Serializer.write(text[2]));
+        compound.put("Text3", NameProvider.Serializer.write(text[3]));
         info.mutationDistributor.accept(compound);
     }
 
@@ -110,16 +115,16 @@ public class LargeSignBlockPart extends SignBlockPart<LargeSignBlockPart> {
             return;
         }
         if (compound.contains("Text0")) {
-            text[0] = compound.getString("Text0");
+            text[0] = NameProvider.fetchFrom(compound.get("Text0"));
         }
         if (compound.contains("Text1")) {
-            text[1] = compound.getString("Text1");
+            text[1] = NameProvider.fetchFrom(compound.get("Text1"));
         }
         if (compound.contains("Text2")) {
-            text[2] = compound.getString("Text2");
+            text[2] = NameProvider.fetchFrom(compound.get("Text2"));
         }
         if (compound.contains("Text3")) {
-            text[3] = compound.getString("Text3");
+            text[3] = NameProvider.fetchFrom(compound.get("Text3"));
         }
         super.readMutationUpdate(compound, tile, editingPlayer);
     }

--- a/src/main/java/gollorum/signpost/blockpartdata/types/SignBlockPart.java
+++ b/src/main/java/gollorum/signpost/blockpartdata/types/SignBlockPart.java
@@ -2,6 +2,7 @@ package gollorum.signpost.blockpartdata.types;
 
 import gollorum.signpost.*;
 import gollorum.signpost.blockpartdata.Overlay;
+import gollorum.signpost.blockpartdata.types.renderers.BlockPartWaystoneUpdateListener;
 import gollorum.signpost.interactions.InteractionInfo;
 import gollorum.signpost.minecraft.block.PostBlock;
 import gollorum.signpost.minecraft.block.tiles.PostTile;
@@ -15,8 +16,9 @@ import gollorum.signpost.relations.ExternalWaystone;
 import gollorum.signpost.security.WithOwner;
 import gollorum.signpost.utils.BlockPart;
 import gollorum.signpost.utils.Either;
-import gollorum.signpost.utils.WaystoneData;
+import gollorum.signpost.utils.NameProvider;
 import gollorum.signpost.utils.math.Angle;
+import gollorum.signpost.utils.AngleProvider;
 import gollorum.signpost.utils.math.geometry.Intersectable;
 import gollorum.signpost.utils.math.geometry.Ray;
 import gollorum.signpost.utils.math.geometry.TransformedBox;
@@ -41,11 +43,12 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 public abstract class SignBlockPart<Self extends SignBlockPart<Self>> implements BlockPart<Self> {
 
     protected static final class CoreData {
-        public Angle angle;
+        public AngleProvider angleProvider;
         public boolean flip;
         public ResourceLocation mainTexture;
         public ResourceLocation secondaryTexture;
@@ -57,7 +60,7 @@ public abstract class SignBlockPart<Self extends SignBlockPart<Self>> implements
         public boolean isLocked;
 
         public CoreData(
-            Angle angle,
+            AngleProvider angleProvider,
             boolean flip,
             ResourceLocation mainTexture,
             ResourceLocation secondaryTexture,
@@ -68,7 +71,7 @@ public abstract class SignBlockPart<Self extends SignBlockPart<Self>> implements
             ItemStack itemToDropOnBreak,
             boolean isLocked
         ) {
-            this.angle = angle;
+            this.angleProvider = angleProvider;
             this.flip = flip;
             this.mainTexture = mainTexture;
             this.secondaryTexture = secondaryTexture;
@@ -82,7 +85,7 @@ public abstract class SignBlockPart<Self extends SignBlockPart<Self>> implements
 
         public CoreData copy() {
             return new CoreData(
-                angle, flip, mainTexture, secondaryTexture, overlay, color, destination, modelType, itemToDropOnBreak, isLocked
+                angleProvider, flip, mainTexture, secondaryTexture, overlay, color, destination, modelType, itemToDropOnBreak, isLocked
             );
         }
 
@@ -91,7 +94,7 @@ public abstract class SignBlockPart<Self extends SignBlockPart<Self>> implements
             private Serializer(){}
             @Override
             public CompoundTag write(CoreData coreData, CompoundTag compound) {
-                compound.put("Angle", Angle.Serializer.write(coreData.angle));
+                compound.put("Angle", AngleProvider.Serializer.write(coreData.angleProvider));
                 compound.putBoolean("Flip", coreData.flip);
                 compound.putString("Texture", coreData.mainTexture.toString());
                 compound.putString("TextureDark", coreData.secondaryTexture.toString());
@@ -132,7 +135,7 @@ public abstract class SignBlockPart<Self extends SignBlockPart<Self>> implements
                     destination = d2;
                 } else destination = Optional.empty();
                 return new CoreData(
-                    Angle.Serializer.read(compound.getCompound("Angle")),
+                    AngleProvider.fetchFrom(compound.getCompound("Angle")),
                     compound.getBoolean("Flip"),
                     new ResourceLocation(compound.getString("Texture")),
                     new ResourceLocation(compound.getString("TextureDark")),
@@ -166,15 +169,31 @@ public abstract class SignBlockPart<Self extends SignBlockPart<Self>> implements
 
     protected SignBlockPart(CoreData coreData) {
         this.coreData = coreData;
-        setAngle(coreData.angle);
+        setAngle(coreData.angleProvider);
         setTextures(coreData.mainTexture, coreData.secondaryTexture);
         setOverlay(coreData.overlay);
         setFlip(coreData.flip);
     }
 
-    public void setAngle(Angle angle) {
-        coreData.angle = angle;
+    public void setAngle(AngleProvider angleProvider) {
+        coreData.angleProvider = angleProvider;
         regenerateTransformedBox();
+    }
+
+    protected abstract NameProvider[] getNameProviders();
+
+    @Override public void attachTo(PostTile tile) {
+        BlockPartWaystoneUpdateListener.getInstance().addListener(this, event ->
+            getDestination().ifPresent(handle -> {
+                if (handle.equals(event.handle)) {
+                    if (getAngle() instanceof AngleProvider.WaystoneTarget)
+                        ((AngleProvider.WaystoneTarget) getAngle()).setCachedAngle(
+                            pointingAt(tile.getBlockPos(), event.location.block.blockPos));
+                    for(NameProvider np : getNameProviders())
+                        if(np instanceof NameProvider.WaystoneTarget)
+                            ((NameProvider.WaystoneTarget)np).setCachedName(event.name);
+                }
+            }));
     }
 
     public void setFlip(boolean flip) {
@@ -256,7 +275,8 @@ public abstract class SignBlockPart<Self extends SignBlockPart<Self>> implements
                     Vector3 diff = info.traceResult.ray.start.negated().add(0.5f, 0.5f, 0.5f).withY(0).normalized();
                     Vector3 rayDir = info.traceResult.ray.dir.withY(0).normalized();
                     Angle angleToPost = Angle.between(rayDir.x, rayDir.z, diff.x, diff.z).normalized();
-                    setAngle(coreData.angle.add(Angle.fromDegrees(angleToPost.radians() < 0 ? 15 : -15)));
+                    setAngle(new AngleProvider.Literal(coreData.angleProvider
+                        .get().add(Angle.fromDegrees(angleToPost.radians() < 0 ? 15 : -15))));
                     notifyAngleChanged(info);
                 }
             } else if(!isBrush(heldItem))
@@ -318,7 +338,7 @@ public abstract class SignBlockPart<Self extends SignBlockPart<Self>> implements
 
     protected void notifyAngleChanged(InteractionInfo info) {
         CompoundTag compound = new CompoundTag();
-        compound.put("Angle", Angle.Serializer.write(coreData.angle));
+        compound.put("Angle", AngleProvider.Serializer.write(coreData.angleProvider));
         info.mutationDistributor.accept(compound);
     }
 
@@ -339,7 +359,7 @@ public abstract class SignBlockPart<Self extends SignBlockPart<Self>> implements
     public void readMutationUpdate(CompoundTag compound, BlockEntity tile, Player editingPlayer) {
         if(compound.contains("CoreData")) compound = compound.getCompound("CoreData");
         if(compound.contains("Angle"))
-            setAngle(Angle.Serializer.read(compound.getCompound("Angle")));
+            setAngle(AngleProvider.fetchFrom(compound.getCompound("Angle")));
 
         boolean updateTextures = false;
         if(compound.contains("Texture")) {
@@ -380,7 +400,7 @@ public abstract class SignBlockPart<Self extends SignBlockPart<Self>> implements
             if(editingPlayer == null || editingPlayer.level.isClientSide()
                 || ((WithOwner.OfSignpost)tile).getSignpostOwner().map(owner -> editingPlayer.getUUID().equals(owner.id)).orElse(true)
                 || editingPlayer.hasPermissions(Config.Server.permissions.editLockedSignCommandPermissionLevel.get()))
-            coreData.isLocked = compound.getBoolean("IsLocked");
+                coreData.isLocked = compound.getBoolean("IsLocked");
         }
         tile.setChanged();
     }
@@ -404,8 +424,8 @@ public abstract class SignBlockPart<Self extends SignBlockPart<Self>> implements
         }
     }
 
-    public Angle getAngle() {
-        return coreData.angle;
+    public AngleProvider getAngle() {
+        return coreData.angleProvider;
     }
 
     public abstract Self copy();

--- a/src/main/java/gollorum/signpost/blockpartdata/types/SmallShortSignBlockPart.java
+++ b/src/main/java/gollorum/signpost/blockpartdata/types/SmallShortSignBlockPart.java
@@ -8,12 +8,12 @@ import gollorum.signpost.minecraft.utils.CoordinatesUtil;
 import gollorum.signpost.minecraft.utils.LangKeys;
 import gollorum.signpost.security.WithOwner;
 import gollorum.signpost.utils.BlockPartMetadata;
-import gollorum.signpost.utils.math.Angle;
+import gollorum.signpost.utils.AngleProvider;
+import gollorum.signpost.utils.NameProvider;
 import gollorum.signpost.utils.math.geometry.AABB;
 import gollorum.signpost.utils.math.geometry.Matrix4x4;
 import gollorum.signpost.utils.math.geometry.TransformedBox;
 import gollorum.signpost.utils.math.geometry.Vector3;
-import net.minecraft.Util;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
@@ -34,28 +34,28 @@ public class SmallShortSignBlockPart extends SignBlockPart<SmallShortSignBlockPa
         "small_short_sign",
         (sign, compound) -> {
             compound.put("CoreData", CoreData.SERIALIZER.write(sign.coreData));
-            compound.putString("Text", sign.text);
+            compound.put("Text", NameProvider.Serializer.write(sign.text));
         },
         (compound) -> new SmallShortSignBlockPart(
             CoreData.SERIALIZER.read(compound.getCompound("CoreData")),
-            compound.getString("Text")
+            NameProvider.fetchFrom(compound.get("Text"))
         ),
         SmallShortSignBlockPart.class
     );
 
-    private String text;
+    private NameProvider text;
 
     public SmallShortSignBlockPart(
         CoreData coreData,
-        String text
+        NameProvider text
     ){
         super(coreData);
         this.text = text;
     }
 
     public SmallShortSignBlockPart(
-        Angle angle,
-        String text,
+        AngleProvider angle,
+        NameProvider text,
         boolean flip,
         ResourceLocation mainTexture,
         ResourceLocation secondaryTexture,
@@ -71,18 +71,23 @@ public class SmallShortSignBlockPart extends SignBlockPart<SmallShortSignBlockPa
         text
     ); }
 
-    public void setText(String text) { this.text = text; }
+    public void setText(NameProvider text) { this.text = text; }
 
-    public String getText() { return text; }
+    public NameProvider getText() { return text; }
+
+    @Override
+    protected NameProvider[] getNameProviders() {
+        return new NameProvider[]{text};
+    }
 
     @Override
     protected void regenerateTransformedBox() {
-        transformedBounds = new TransformedBox(LOCAL_BOUNDS).rotateAlong(Matrix4x4.Axis.Y, coreData.angle);
+        transformedBounds = new TransformedBox(LOCAL_BOUNDS).rotateAlong(Matrix4x4.Axis.Y, coreData.angleProvider.get());
     }
 
     private void notifyTextChanged(InteractionInfo info) {
         CompoundTag compound = new CompoundTag();
-        compound.putString("Text", text);
+        compound.put("Text", NameProvider.Serializer.write(text));
         info.mutationDistributor.accept(compound);
     }
 
@@ -98,7 +103,7 @@ public class SmallShortSignBlockPart extends SignBlockPart<SmallShortSignBlockPa
             return;
         }
         if (compound.contains("Text")) {
-            setText(compound.getString("Text"));
+            setText(NameProvider.fetchFrom(compound.get("Text")));
         }
         super.readMutationUpdate(compound, tile, editingPlayer);
     }

--- a/src/main/java/gollorum/signpost/blockpartdata/types/renderers/BlockPartWaystoneUpdateListener.java
+++ b/src/main/java/gollorum/signpost/blockpartdata/types/renderers/BlockPartWaystoneUpdateListener.java
@@ -7,6 +7,7 @@ import gollorum.signpost.utils.BlockPart;
 import java.lang.ref.WeakReference;
 import java.util.Map;
 import java.util.WeakHashMap;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 public final class BlockPartWaystoneUpdateListener {
@@ -14,22 +15,19 @@ public final class BlockPartWaystoneUpdateListener {
     private static final BlockPartWaystoneUpdateListener instance = new BlockPartWaystoneUpdateListener();
     public static BlockPartWaystoneUpdateListener getInstance() { return instance; }
 
-    private final WeakHashMap<BlockPart<?>, WeakReference<Consumer<WaystoneUpdatedEvent>>> listeners = new WeakHashMap<>();
+    private final WeakHashMap<BlockPart<?>, BiConsumer<BlockPart<?>, WaystoneUpdatedEvent>> listeners = new WeakHashMap<>();
 
-    public void addListener(BlockPart<?> part, Consumer<WaystoneUpdatedEvent> onUpdate) {
-        listeners.put(part, new WeakReference<>(onUpdate));
+    public <T extends BlockPart<T>> void addListener(T part, BiConsumer<T, WaystoneUpdatedEvent> onUpdate) {
+        listeners.put(part, (untypedPart, event) -> onUpdate.accept((T)untypedPart, event));
     }
 
     private BlockPartWaystoneUpdateListener(){}
 
     public void initialize() {
+        listeners.clear();
         WaystoneLibrary.getInstance().updateEventDispatcher.addListener(event -> {
-            for (Map.Entry<BlockPart<?>, WeakReference<Consumer<WaystoneUpdatedEvent>>> entry : listeners.entrySet().stream().toList()) {
-                Consumer<WaystoneUpdatedEvent> onUpdate = entry.getValue().get();
-                if(onUpdate == null)
-                    listeners.remove(entry.getKey());
-                else onUpdate.accept(event);
-            }
+            for (Map.Entry<BlockPart<?>, BiConsumer<BlockPart<?>, WaystoneUpdatedEvent>> entry : listeners.entrySet().stream().toList())
+                entry.getValue().accept(entry.getKey(), event);
         });
     }
 

--- a/src/main/java/gollorum/signpost/blockpartdata/types/renderers/BlockPartWaystoneUpdateListener.java
+++ b/src/main/java/gollorum/signpost/blockpartdata/types/renderers/BlockPartWaystoneUpdateListener.java
@@ -1,0 +1,36 @@
+package gollorum.signpost.blockpartdata.types.renderers;
+
+import gollorum.signpost.WaystoneLibrary;
+import gollorum.signpost.minecraft.events.WaystoneUpdatedEvent;
+import gollorum.signpost.utils.BlockPart;
+
+import java.lang.ref.WeakReference;
+import java.util.Map;
+import java.util.WeakHashMap;
+import java.util.function.Consumer;
+
+public final class BlockPartWaystoneUpdateListener {
+
+    private static final BlockPartWaystoneUpdateListener instance = new BlockPartWaystoneUpdateListener();
+    public static BlockPartWaystoneUpdateListener getInstance() { return instance; }
+
+    private final WeakHashMap<BlockPart<?>, WeakReference<Consumer<WaystoneUpdatedEvent>>> listeners = new WeakHashMap<>();
+
+    public void addListener(BlockPart<?> part, Consumer<WaystoneUpdatedEvent> onUpdate) {
+        listeners.put(part, new WeakReference<>(onUpdate));
+    }
+
+    private BlockPartWaystoneUpdateListener(){}
+
+    public void initialize() {
+        WaystoneLibrary.getInstance().updateEventDispatcher.addListener(event -> {
+            for (Map.Entry<BlockPart<?>, WeakReference<Consumer<WaystoneUpdatedEvent>>> entry : listeners.entrySet().stream().toList()) {
+                Consumer<WaystoneUpdatedEvent> onUpdate = entry.getValue().get();
+                if(onUpdate == null)
+                    listeners.remove(entry.getKey());
+                else onUpdate.accept(event);
+            }
+        });
+    }
+
+}

--- a/src/main/java/gollorum/signpost/blockpartdata/types/renderers/LargeSignRenderer.java
+++ b/src/main/java/gollorum/signpost/blockpartdata/types/renderers/LargeSignRenderer.java
@@ -51,16 +51,16 @@ public class LargeSignRenderer extends SignRenderer<LargeSignBlockPart> {
 			matrix.mulPose(Vector3f.ZP.rotationDegrees(180));
 			matrix.translate(0, 3.5f * VoxelSize, -3.005 * VoxelSize);
 
-			RenderingUtil.wrapInMatrixEntry(matrix, () -> render(sign, fontRenderer, sign.getText()[3], matrix, buffer, combinedLights, false));
+			RenderingUtil.wrapInMatrixEntry(matrix, () -> render(sign, fontRenderer, sign.getText()[3].get(), matrix, buffer, combinedLights, false));
 			matrix.translate(0, -7 / 3f * VoxelSize, 0);
 
-			RenderingUtil.wrapInMatrixEntry(matrix, () -> render(sign, fontRenderer, sign.getText()[2], matrix, buffer, combinedLights, false));
+			RenderingUtil.wrapInMatrixEntry(matrix, () -> render(sign, fontRenderer, sign.getText()[2].get(), matrix, buffer, combinedLights, false));
 			matrix.translate(0, -7 / 3f * VoxelSize, 0);
 
-			RenderingUtil.wrapInMatrixEntry(matrix, () -> render(sign, fontRenderer, sign.getText()[1], matrix, buffer, combinedLights, false));
+			RenderingUtil.wrapInMatrixEntry(matrix, () -> render(sign, fontRenderer, sign.getText()[1].get(), matrix, buffer, combinedLights, false));
 			matrix.translate(0, -7 / 3f * VoxelSize, 0);
 
-			RenderingUtil.wrapInMatrixEntry(matrix, () -> render(sign, fontRenderer, sign.getText()[0], matrix, buffer, combinedLights, false));
+			RenderingUtil.wrapInMatrixEntry(matrix, () -> render(sign, fontRenderer, sign.getText()[0].get(), matrix, buffer, combinedLights, false));
 		});
 	}
 

--- a/src/main/java/gollorum/signpost/blockpartdata/types/renderers/PostRenderer.java
+++ b/src/main/java/gollorum/signpost/blockpartdata/types/renderers/PostRenderer.java
@@ -3,6 +3,7 @@ package gollorum.signpost.blockpartdata.types.renderers;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Matrix4f;
 import com.mojang.math.Quaternion;
+import gollorum.signpost.blockpartdata.types.BlockPartRenderer;
 import gollorum.signpost.blockpartdata.types.PostBlockPart;
 import gollorum.signpost.minecraft.data.PostModel;
 import gollorum.signpost.minecraft.gui.utils.Point;

--- a/src/main/java/gollorum/signpost/blockpartdata/types/renderers/ShortSignRenderer.java
+++ b/src/main/java/gollorum/signpost/blockpartdata/types/renderers/ShortSignRenderer.java
@@ -54,17 +54,17 @@ public class ShortSignRenderer extends SignRenderer<SmallShortSignBlockPart> {
 		RenderingUtil.wrapInMatrixEntry(matrix, () -> {
 			matrix.mulPose(Vector3f.ZP.rotationDegrees(180));
 			float scale = FONT_SIZE_VOXELS * FontToVoxelSize;
-			float MAX_WIDTH_FRAC = fontRenderer.width(sign.getText()) * scale / MAXIMUM_TEXT_WIDTH;
+			float MAX_WIDTH_FRAC = fontRenderer.width(sign.getText().get()) * scale / MAXIMUM_TEXT_WIDTH;
 			scale /= Math.max(1, MAX_WIDTH_FRAC);
 			boolean flipped = isFlipped ^ sign.isFlipped();
 			if(isFlipped) matrix.mulPose(Vector3f.YP.rotation((float) Math.PI));
 			float offset = MathUtils.lerp(TEXT_OFFSET_RIGHT, (TEXT_OFFSET_RIGHT - TEXT_OFFSET_LEFT) / 2f, 1 - Math.min(1, MAX_WIDTH_FRAC));
 			matrix.translate(
-				flipped ? offset - fontRenderer.width(sign.getText()) * scale : -offset,
+				flipped ? offset - fontRenderer.width(sign.getText().get()) * scale : -offset,
 				-scale * 4 * TEXT_RATIO,
 				-0.505 * VoxelSize);
 			matrix.scale(scale, scale * TEXT_RATIO, scale);
-			fontRenderer.drawInBatch(sign.getText(), 0, 0, sign.getColor(), false, matrix.last().pose(), buffer, false, 0, combinedLights);
+			fontRenderer.drawInBatch(sign.getText().get(), 0, 0, sign.getColor(), false, matrix.last().pose(), buffer, false, 0, combinedLights);
 		});
 	}
 

--- a/src/main/java/gollorum/signpost/blockpartdata/types/renderers/SignRenderer.java
+++ b/src/main/java/gollorum/signpost/blockpartdata/types/renderers/SignRenderer.java
@@ -5,6 +5,7 @@ import com.mojang.math.Matrix4f;
 import com.mojang.math.Quaternion;
 import com.mojang.math.Vector3f;
 import gollorum.signpost.blockpartdata.Overlay;
+import gollorum.signpost.blockpartdata.types.BlockPartRenderer;
 import gollorum.signpost.blockpartdata.types.SignBlockPart;
 import gollorum.signpost.minecraft.gui.utils.Colors;
 import gollorum.signpost.minecraft.gui.utils.Point;
@@ -35,7 +36,7 @@ public abstract class SignRenderer<T extends SignBlockPart<T>> extends BlockPart
 		RenderingUtil.render(matrix, renderModel -> {
 			if(!tileEntity.hasLevel()) throw new RuntimeException("TileEntity without world cannot be rendered.");
 			RenderingUtil.wrapInMatrixEntry(matrix, () -> {
-				Quaternion rotation = new Quaternion(Vector3f.YP, sign.getAngle().radians(), false);
+				Quaternion rotation = new Quaternion(Vector3f.YP, sign.getAngle().get().radians(), false);
 				matrix.mulPose(rotation);
 				RenderingUtil.wrapInMatrixEntry(matrix, () -> {
 					if(!sign.isFlipped()) matrix.mulPose(new Quaternion(Vector3f.YP, 180, true));
@@ -87,7 +88,7 @@ public abstract class SignRenderer<T extends SignBlockPart<T>> extends BlockPart
 
 	@Override
 	public void renderGui(T sign, PoseStack matrixStack, Point center, Angle yaw, Angle pitch, boolean isFlipped, float scale, Vector3 offset) {
-		RenderingUtil.renderGui(makeBakedModel(sign), matrixStack, 0xffffff, center, yaw.add(sign.getAngle()), pitch, isFlipped, scale, offset, RenderType.solid(),
+		RenderingUtil.renderGui(makeBakedModel(sign), matrixStack, 0xffffff, center, yaw.add(sign.getAngle().get()), pitch, isFlipped, scale, offset, RenderType.solid(),
 			ms -> RenderingUtil.wrapInMatrixEntry(ms, () -> {
 				if(!sign.isFlipped())
 					ms.mulPose(new Quaternion(Vector3f.YP, 180, true));
@@ -95,12 +96,12 @@ public abstract class SignRenderer<T extends SignBlockPart<T>> extends BlockPart
 			})
 		);
 		sign.getOverlay().ifPresent(o ->
-			RenderingUtil.renderGui(makeBakedOverlayModel(sign, o), matrixStack, o.getDefaultTint(), center, yaw.add(sign.getAngle()), pitch, isFlipped, scale, offset, RenderType.cutout(), m -> {}));
+			RenderingUtil.renderGui(makeBakedOverlayModel(sign, o), matrixStack, o.getDefaultTint(), center, yaw.add(sign.getAngle().get()), pitch, isFlipped, scale, offset, RenderType.cutout(), m -> {}));
 	}
 
 	@Override
 	public void renderGui(T sign, PoseStack matrixStack, Vector3 offset, MultiBufferSource buffer, int combinedLight, int combinedOverlay) {
-		RenderingUtil.renderGui(makeBakedModel(sign), matrixStack, 0xffffff, offset, sign.getAngle(), buffer.getBuffer(RenderType.solid()), RenderType.solid(), combinedLight, combinedOverlay,
+		RenderingUtil.renderGui(makeBakedModel(sign), matrixStack, 0xffffff, offset, sign.getAngle().get(), buffer.getBuffer(RenderType.solid()), RenderType.solid(), combinedLight, combinedOverlay,
 			ms -> RenderingUtil.wrapInMatrixEntry(matrixStack, () -> {
 				if(!sign.isFlipped())
 					matrixStack.mulPose(new Quaternion(Vector3f.YP, 180, true));
@@ -108,7 +109,7 @@ public abstract class SignRenderer<T extends SignBlockPart<T>> extends BlockPart
 			})
 		);
 		sign.getOverlay().ifPresent(o -> {
-			RenderingUtil.renderGui(makeBakedOverlayModel(sign, o), matrixStack, o.getDefaultTint(), offset, sign.getAngle(), buffer.getBuffer(RenderType.cutout()), RenderType.solid(), combinedLight, combinedOverlay, m -> {});
+			RenderingUtil.renderGui(makeBakedOverlayModel(sign, o), matrixStack, o.getDefaultTint(), offset, sign.getAngle().get(), buffer.getBuffer(RenderType.cutout()), RenderType.solid(), combinedLight, combinedOverlay, m -> {});
 		});
 	}
 

--- a/src/main/java/gollorum/signpost/blockpartdata/types/renderers/WaystoneRenderer.java
+++ b/src/main/java/gollorum/signpost/blockpartdata/types/renderers/WaystoneRenderer.java
@@ -3,6 +3,7 @@ package gollorum.signpost.blockpartdata.types.renderers;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Matrix4f;
 import com.mojang.math.Quaternion;
+import gollorum.signpost.blockpartdata.types.BlockPartRenderer;
 import gollorum.signpost.blockpartdata.types.WaystoneBlockPart;
 import gollorum.signpost.minecraft.data.WaystoneModel;
 import gollorum.signpost.minecraft.gui.utils.Point;

--- a/src/main/java/gollorum/signpost/blockpartdata/types/renderers/WideSignRenderer.java
+++ b/src/main/java/gollorum/signpost/blockpartdata/types/renderers/WideSignRenderer.java
@@ -48,15 +48,15 @@ public class WideSignRenderer extends SignRenderer<SmallWideSignBlockPart> {
 		RenderingUtil.wrapInMatrixEntry(matrix, () -> {
 			matrix.mulPose(Vector3f.ZP.rotationDegrees(180));
 			float scale = FONT_SIZE_VOXELS * FontToVoxelSize;
-			float MAX_WIDTH_FRAC = fontRenderer.width(sign.getText()) * scale / MAXIMUM_TEXT_WIDTH;
+			float MAX_WIDTH_FRAC = fontRenderer.width(sign.getText().get()) * scale / MAXIMUM_TEXT_WIDTH;
 			scale /= Math.max(1, MAX_WIDTH_FRAC);
 			float offset = TEXT_OFFSET_RIGHT * Math.min(1, MAX_WIDTH_FRAC);
 			matrix.translate(
-				sign.isFlipped() ? offset - fontRenderer.width(sign.getText()) * scale : -offset,
+				sign.isFlipped() ? offset - fontRenderer.width(sign.getText().get()) * scale : -offset,
 				-scale * 4 * TEXT_RATIO,
 				-3.005 * VoxelSize);
 			matrix.scale(scale, scale * TEXT_RATIO, scale);
-			fontRenderer.drawInBatch(sign.getText(), 0, 0, sign.getColor(), false, matrix.last().pose(), buffer, false, 0, combinedLights);
+			fontRenderer.drawInBatch(sign.getText().get(), 0, 0, sign.getColor(), false, matrix.last().pose(), buffer, false, 0, combinedLights);
 		});
 	}
 

--- a/src/main/java/gollorum/signpost/minecraft/block/BlockEventListener.java
+++ b/src/main/java/gollorum/signpost/minecraft/block/BlockEventListener.java
@@ -4,12 +4,14 @@ import gollorum.signpost.BlockRestrictions;
 import gollorum.signpost.PlayerHandle;
 import gollorum.signpost.blockpartdata.types.PostBlockPart;
 import gollorum.signpost.minecraft.block.tiles.PostTile;
+import gollorum.signpost.minecraft.block.tiles.WaystoneTile;
 import gollorum.signpost.security.WithCountRestriction;
 import gollorum.signpost.utils.Delay;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraftforge.event.level.BlockEvent;
@@ -68,6 +70,10 @@ public class BlockEventListener {
             BlockRestrictions.Type restrictionType = ((WithCountRestriction)block).getBlockRestrictionType();
             restrictionType.tryGetOwner.apply(tile).ifPresent(owner ->
                 BlockRestrictions.getInstance().incrementRemaining(restrictionType, owner));
+
+            if(event.getLevel() instanceof ServerLevel) {
+                WaystoneTile.onRemoved((ServerLevel) event.getLevel(), event.getPos());
+            }
         }
     }
 

--- a/src/main/java/gollorum/signpost/minecraft/block/ModelWaystone.java
+++ b/src/main/java/gollorum/signpost/minecraft/block/ModelWaystone.java
@@ -30,6 +30,7 @@ import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.level.material.Material;
 import net.minecraft.world.level.material.MaterialColor;
 import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
@@ -158,7 +159,7 @@ public class ModelWaystone extends BaseEntityBlock implements SimpleWaterloggedB
 	@Override
 	public void setPlacedBy(Level world, BlockPos pos, BlockState state, LivingEntity placer, ItemStack stack) {
 		super.setPlacedBy(world, pos, state, placer, stack);
-		WaystoneBlock.registerOwnerAndRequestGui(world, pos, placer);
+		WaystoneBlock.registerOwnerAndRequestGui(world, pos, placer, stack);
 	}
 
 	@Override
@@ -203,5 +204,12 @@ public class ModelWaystone extends BaseEntityBlock implements SimpleWaterloggedB
 			WaystoneTile.onRemoved((ServerLevel) world, pos);
 		}
 	}
+
+	// Does this work with silk touch?
+	@Override
+	public ItemStack getCloneItemStack(BlockState state, HitResult target, BlockGetter level, BlockPos pos, Player player) {
+		return WaystoneBlock.fillClonedItemStack(super.getCloneItemStack(state, target, level, pos, player), level, pos, player);
+	}
+
 
 }

--- a/src/main/java/gollorum/signpost/minecraft/block/ModelWaystone.java
+++ b/src/main/java/gollorum/signpost/minecraft/block/ModelWaystone.java
@@ -205,7 +205,6 @@ public class ModelWaystone extends BaseEntityBlock implements SimpleWaterloggedB
 		}
 	}
 
-	// Does this work with silk touch?
 	@Override
 	public ItemStack getCloneItemStack(BlockState state, HitResult target, BlockGetter level, BlockPos pos, Player player) {
 		return WaystoneBlock.fillClonedItemStack(super.getCloneItemStack(state, target, level, pos, player), level, pos, player);

--- a/src/main/java/gollorum/signpost/minecraft/block/PostBlock.java
+++ b/src/main/java/gollorum/signpost/minecraft/block/PostBlock.java
@@ -322,7 +322,7 @@ public class PostBlock extends BaseEntityBlock implements SimpleWaterloggedBlock
         super.setPlacedBy(world, pos, state, placer, currentStack);
         ItemStack stack = currentStack.copy();
         Delay.forFrames(6, world.isClientSide(), () ->
-            TileEntityUtils.delayUntilTileEntityExists(world, pos, PostTile.class, tile -> {
+            TileEntityUtils.delayUntilTileEntityExists(world, pos, PostTile.getBlockEntityType(), tile -> {
                 tile.setSignpostOwner(Optional.of(PlayerHandle.from(placer)));
                 boolean shouldAddNewSign = placer instanceof ServerPlayer;
                 if (!world.isClientSide()) {
@@ -374,7 +374,7 @@ public class PostBlock extends BaseEntityBlock implements SimpleWaterloggedBlock
     @Override
     public ItemStack getCloneItemStack(BlockState state, HitResult target, BlockGetter world, BlockPos pos, Player player) {
         ItemStack ret = super.getCloneItemStack(state, target, world, pos, player);
-        TileEntityUtils.findTileEntity(world, pos, PostTile.class).ifPresent(tile -> {
+        world.getBlockEntity(pos, PostTile.getBlockEntityType()).ifPresent(tile -> {
             if(!ret.hasTag()) ret.setTag(new CompoundTag());
             ret.getTag().put("Parts", tile.writeParts(false));
         });

--- a/src/main/java/gollorum/signpost/minecraft/block/WaystoneBlock.java
+++ b/src/main/java/gollorum/signpost/minecraft/block/WaystoneBlock.java
@@ -134,7 +134,7 @@ public class WaystoneBlock extends BaseEntityBlock implements WithCountRestricti
 
     public static void registerOwnerAndRequestGui(Level world, BlockPos pos, LivingEntity placer, ItemStack stack) {
         Delay.forFrames(6, world.isClientSide(), () ->
-            TileEntityUtils.delayUntilTileEntityExists(world, pos, WaystoneTile.class, t -> {
+            TileEntityUtils.delayUntilTileEntityExists(world, pos, WaystoneTile.getBlockEntityType(), t -> {
                 t.setWaystoneOwner(Optional.of(PlayerHandle.from(placer)));
                 if(placer instanceof ServerPlayer) {
                     WorldLocation worldLocation = new WorldLocation(pos, world);

--- a/src/main/java/gollorum/signpost/minecraft/block/WaystoneBlock.java
+++ b/src/main/java/gollorum/signpost/minecraft/block/WaystoneBlock.java
@@ -186,7 +186,6 @@ public class WaystoneBlock extends BaseEntityBlock implements WithCountRestricti
         }
     }
 
-    // Does this work with silk touch?
     @Override
     public ItemStack getCloneItemStack(BlockState state, HitResult target, BlockGetter level, BlockPos pos, Player player) {
         return fillClonedItemStack(super.getCloneItemStack(state, target, level, pos, player), level, pos, player);

--- a/src/main/java/gollorum/signpost/minecraft/block/WaystoneBlock.java
+++ b/src/main/java/gollorum/signpost/minecraft/block/WaystoneBlock.java
@@ -1,10 +1,8 @@
 package gollorum.signpost.minecraft.block;
 
-import gollorum.signpost.BlockRestrictions;
-import gollorum.signpost.PlayerHandle;
-import gollorum.signpost.Signpost;
-import gollorum.signpost.WaystoneLibrary;
+import gollorum.signpost.*;
 import gollorum.signpost.minecraft.block.tiles.WaystoneTile;
+import gollorum.signpost.minecraft.config.Config;
 import gollorum.signpost.minecraft.gui.RequestWaystoneGui;
 import gollorum.signpost.minecraft.utils.LangKeys;
 import gollorum.signpost.minecraft.utils.TextComponents;
@@ -13,9 +11,11 @@ import gollorum.signpost.networking.PacketHandler;
 import gollorum.signpost.security.WithCountRestriction;
 import gollorum.signpost.utils.Delay;
 import gollorum.signpost.utils.WaystoneData;
+import gollorum.signpost.utils.WaystoneLocationData;
 import gollorum.signpost.utils.WorldLocation;
-import net.minecraft.Util;
+import gollorum.signpost.utils.math.geometry.Vector3;
 import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
@@ -25,6 +25,7 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
+import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.BaseEntityBlock;
@@ -38,6 +39,7 @@ import net.minecraft.world.level.block.state.properties.DirectionProperty;
 import net.minecraft.world.level.material.Material;
 import net.minecraft.world.level.material.MaterialColor;
 import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.HitResult;
 import net.minecraftforge.network.PacketDistributor;
 
 import javax.annotation.Nullable;
@@ -127,18 +129,43 @@ public class WaystoneBlock extends BaseEntityBlock implements WithCountRestricti
     @Override
     public void setPlacedBy(Level world, BlockPos pos, BlockState state, LivingEntity placer, ItemStack stack) {
         super.setPlacedBy(world, pos, state, placer, stack);
-        registerOwnerAndRequestGui(world, pos, placer);
+        registerOwnerAndRequestGui(world, pos, placer, stack);
     }
 
-    public static void registerOwnerAndRequestGui(Level world, BlockPos pos, LivingEntity placer) {
+    public static void registerOwnerAndRequestGui(Level world, BlockPos pos, LivingEntity placer, ItemStack stack) {
         Delay.forFrames(6, world.isClientSide(), () ->
             TileEntityUtils.delayUntilTileEntityExists(world, pos, WaystoneTile.class, t -> {
                 t.setWaystoneOwner(Optional.of(PlayerHandle.from(placer)));
-                if(placer instanceof ServerPlayer) PacketHandler.send(
-                    PacketDistributor.PLAYER.with(() -> (ServerPlayer) placer),
-                    new RequestWaystoneGui.Package(new WorldLocation(pos, world), Optional.empty())
-                );
+                if(placer instanceof ServerPlayer) {
+                    WorldLocation worldLocation = new WorldLocation(pos, world);
+                    boolean wasRegistered = getCustomName(stack).map(name -> {
+                        WaystoneLocationData locationData = new WaystoneLocationData(worldLocation, Vector3.fromVec3d(placer.position()));
+                        CompoundTag handleTag = stack.getTagElement("Handle");
+                        Optional<WaystoneHandle.Vanilla> handle = handleTag != null ? Optional.of(WaystoneHandle.Vanilla.Serializer.read(handleTag)) : Optional.empty();
+                        return WaystoneLibrary.getInstance().tryAddNew(name, locationData, (ServerPlayer) placer, handle);
+                    }).orElse(false);
+                    if(!wasRegistered)
+                        PacketHandler.send(
+                            PacketDistributor.PLAYER.with(() -> (ServerPlayer) placer),
+                            new RequestWaystoneGui.Package(worldLocation, Optional.empty())
+                        );
+                }
             }, 100, Optional.empty()));
+    }
+
+    // Modified copy of ItemStack.getHoverName()
+    private static Optional<String> getCustomName(ItemStack stack) {
+        CompoundTag displayTag = stack.getTagElement("display");
+        if (displayTag != null && displayTag.contains("Name", 8)) {
+            try {
+                Component component = Component.Serializer.fromJson(displayTag.getString("Name"));
+                if (component != null) {
+                    return Optional.of(component.getString());
+                }
+
+            } catch (Exception ignored) {}
+        }
+        return Optional.empty();
     }
 
     @Override
@@ -159,4 +186,23 @@ public class WaystoneBlock extends BaseEntityBlock implements WithCountRestricti
         }
     }
 
+    // Does this work with silk touch?
+    @Override
+    public ItemStack getCloneItemStack(BlockState state, HitResult target, BlockGetter level, BlockPos pos, Player player) {
+        return fillClonedItemStack(super.getCloneItemStack(state, target, level, pos, player), level, pos, player);
+    }
+
+    public static ItemStack fillClonedItemStack(ItemStack stack, BlockGetter level, BlockPos pos, Player player) {
+        BlockEntity untypedEntity = level.getBlockEntity(pos);
+        if(untypedEntity instanceof WaystoneTile) {
+            WaystoneTile tile = (WaystoneTile) untypedEntity;
+            if(player.hasPermissions(Config.Server.permissions.pickUnownedWaystonePermissionLevel.get())
+                || tile.getWaystoneOwner().map(o -> o.equals(PlayerHandle.from(player))).orElse(true)) {
+
+                tile.getHandle().ifPresent(h -> stack.addTagElement("Handle", WaystoneHandle.Vanilla.Serializer.write(h)));
+                tile.getName().ifPresent(n -> stack.setHoverName(Component.literal(n)));
+            }
+        }
+        return stack;
+    }
 }

--- a/src/main/java/gollorum/signpost/minecraft/block/tiles/WaystoneTile.java
+++ b/src/main/java/gollorum/signpost/minecraft/block/tiles/WaystoneTile.java
@@ -43,20 +43,11 @@ public class WaystoneTile extends BlockEntity implements WithOwner.OfWaystone, W
     }
 
     private final EventDispatcher.Listener<WaystoneUpdatedEvent> updateListener = event -> {
-        if(!WorldLocation.from(this).map(loc -> loc.equals(event.location.block)).orElse(false)) return false;
-        switch (event.getType()) {
-            case Added:
-            case Renamed:
-            case Moved:
-                name = Optional.of(event.name);
-                handle = Optional.of(event.handle);
-                return false;
-            case Removed:
-                 name = Optional.empty();
-                 handle = Optional.empty();
-                 return true;
-            default: return false;
+        if(WorldLocation.from(this).map(loc -> loc.equals(event.location.block)).orElse(false)) {
+            name = Optional.of(event.name);
+            handle = Optional.of(event.handle);
         }
+        return false;
     };
 
     @Override

--- a/src/main/java/gollorum/signpost/minecraft/block/tiles/WaystoneTile.java
+++ b/src/main/java/gollorum/signpost/minecraft/block/tiles/WaystoneTile.java
@@ -1,14 +1,16 @@
 package gollorum.signpost.minecraft.block.tiles;
 
 import gollorum.signpost.PlayerHandle;
+import gollorum.signpost.WaystoneHandle;
 import gollorum.signpost.WaystoneLibrary;
 import gollorum.signpost.minecraft.block.WaystoneBlock;
+import gollorum.signpost.minecraft.events.WaystoneUpdatedEvent;
 import gollorum.signpost.security.WithOwner;
-import gollorum.signpost.utils.WaystoneContainer;
-import gollorum.signpost.utils.WorldLocation;
+import gollorum.signpost.utils.*;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
@@ -26,13 +28,49 @@ public class WaystoneTile extends BlockEntity implements WithOwner.OfWaystone, W
 
     private Optional<PlayerHandle> owner = Optional.empty();
 
+    private Optional<WaystoneHandle.Vanilla> handle = Optional.empty();
+    public Optional<WaystoneHandle.Vanilla> getHandle() { return handle; }
+
+    private Optional<String> name = Optional.empty();
+    public Optional<String> getName() { return name; }
+
     public WaystoneTile(BlockPos pos, BlockState state) {
         super(type, pos, state);
     }
 
+    private final EventDispatcher.Listener<WaystoneUpdatedEvent> updateListener = event -> {
+        if(!WorldLocation.from(this).map(loc -> loc.equals(event.location.block)).orElse(false)) return false;
+        switch (event.getType()) {
+            case Added:
+            case Renamed:
+            case Moved:
+                name = Optional.of(event.name);
+                handle = Optional.of(event.handle);
+                return false;
+            case Removed:
+                 name = Optional.empty();
+                 handle = Optional.empty();
+                 return true;
+            default: return false;
+        }
+    };
+
+    @Override
+    public void setLevel(Level level) {
+        super.setLevel(level);
+        Delay.forFrames(10, level.isClientSide(), () -> {
+            WaystoneLibrary.getInstance().requestWaystoneAt(new WorldLocation(getBlockPos(), level),
+                data -> {
+                    handle = data.map(d -> d.handle);
+                    name = data.map(d -> d.name);
+                },
+                level.isClientSide());
+            WaystoneLibrary.getInstance().updateEventDispatcher.addListener(updateListener);
+        });
+    }
+
     public static void onRemoved(ServerLevel world, BlockPos pos) {
-        if(!world.isClientSide())
-            WaystoneLibrary.getInstance().removeAt(new WorldLocation(pos, world), PlayerHandle.Invalid);
+        WaystoneLibrary.getInstance().removeAt(new WorldLocation(pos, world), PlayerHandle.Invalid);
     }
 
     @Override
@@ -54,4 +92,5 @@ public class WaystoneTile extends BlockEntity implements WithOwner.OfWaystone, W
         super.load(compound);
         owner = PlayerHandle.Serializer.optional().read(compound.getCompound("Owner"));
     }
+
 }

--- a/src/main/java/gollorum/signpost/minecraft/block/tiles/WaystoneTile.java
+++ b/src/main/java/gollorum/signpost/minecraft/block/tiles/WaystoneTile.java
@@ -25,6 +25,10 @@ public class WaystoneTile extends BlockEntity implements WithOwner.OfWaystone, W
     public static BlockEntityType<WaystoneTile> createType() {
         return type = BlockEntityType.Builder.of(WaystoneTile::new, WaystoneBlock.getInstance()).build(null);
     }
+    public static BlockEntityType<WaystoneTile> getBlockEntityType() {
+        assert type != null;
+        return type;
+    }
 
     private Optional<PlayerHandle> owner = Optional.empty();
 

--- a/src/main/java/gollorum/signpost/minecraft/commands/BlockRestrictions.java
+++ b/src/main/java/gollorum/signpost/minecraft/commands/BlockRestrictions.java
@@ -67,7 +67,7 @@ public class BlockRestrictions {
 
 	private static ArgumentBuilder<CommandSourceStack, ?> setter(gollorum.signpost.BlockRestrictions.Type type) {
 		return LiteralArgumentBuilder.<CommandSourceStack>literal("set")
-			.requires(source -> source.hasPermission(Config.Server.permissions.setBlockResPermissionLevel.get()))
+			.requires(source -> source.hasPermission(Config.Server.permissions.setBlockRestrictionPermissionLevel.get()))
 			.then(Commands.argument("count", IntegerArgumentType.integer(-1))
 				.executes(context -> {
 					ServerPlayer player = context.getSource().getPlayerOrException();

--- a/src/main/java/gollorum/signpost/minecraft/config/PermissionConfig.java
+++ b/src/main/java/gollorum/signpost/minecraft/config/PermissionConfig.java
@@ -9,8 +9,10 @@ public class PermissionConfig {
 	public final ForgeConfigSpec.ConfigValue<Integer> editLockedSignCommandPermissionLevel;
 	public final ForgeConfigSpec.ConfigValue<Integer> teleportPermissionLevel;
 	public final ForgeConfigSpec.ConfigValue<Integer> discoverPermissionLevel;
-	public final ForgeConfigSpec.ConfigValue<Integer> setBlockResPermissionLevel;
+	public final ForgeConfigSpec.ConfigValue<Integer> setBlockRestrictionPermissionLevel;
 	public final ForgeConfigSpec.ConfigValue<Integer> listPermissionLevel;
+
+	public final ForgeConfigSpec.ConfigValue<Integer> pickUnownedWaystonePermissionLevel;
 
 	public final ForgeConfigSpec.ConfigValue<Integer> defaultMaxWaystonesPerPlayer;
 	public final ForgeConfigSpec.ConfigValue<Integer> defaultMaxSignpostsPerPlayer;
@@ -18,8 +20,12 @@ public class PermissionConfig {
 	public PermissionConfig(ForgeConfigSpec.Builder builder) {
 		teleportPermissionLevel = builder.define("teleport_command_permission_level", 3);
 		discoverPermissionLevel = builder.define("discover_command_permission_level", 3);
-		setBlockResPermissionLevel = builder.define("block_restrictions_set_command_permission_level", 3);
+		setBlockRestrictionPermissionLevel = builder.define("block_restrictions_set_command_permission_level", 3);
 		listPermissionLevel = builder.define("list_command_permission_level", 3);
+
+		pickUnownedWaystonePermissionLevel = builder
+			.comment("Defines who (except the owner) can move a waystone by picking it / destroying it with silk touch")
+			.define("pick_unowned_waystone_permission_level", 3);
 
 		editLockedWaystoneCommandPermissionLevel = builder.define("edit_locked_waystones_permission_level", 3);
 		editLockedSignCommandPermissionLevel = builder.define("edit_locked_signs_permission_level", 3);

--- a/src/main/java/gollorum/signpost/minecraft/config/WorldGenConfig.java
+++ b/src/main/java/gollorum/signpost/minecraft/config/WorldGenConfig.java
@@ -61,7 +61,7 @@ public class WorldGenConfig {
 		private static final List<String> englishNamePostfixes = Lists.newArrayList("ville", "bridge", "ham", " island", "cester", "water", "town", " creek", " valley", "view", "bury", "burgh", "ington", "field", "dale", " port", "worth", "sey", "don", "pool", "wood", "ley", "ford", " hill", "gate");
 
 		Naming(ForgeConfigSpec.Builder builder) {
-			villageNamePrefixes = builder.comment("", "The names of waystones generated in villages will consist of a prefix, an infix and a postfix, each randomly selected from these lists.",
+			villageNamePrefixes = builder.comment("The names of waystones generated in villages will consist of a prefix, an infix and a postfix, each randomly selected from these lists.",
 				"e.g.: If \"tol \", \"ker\" and \"dra\" are selected, the name will be \"Tol Kerdra\"",
 				"Here are some language-specific examples:",
 				"english:",

--- a/src/main/java/gollorum/signpost/minecraft/crafting/CutWaystoneRecipe.java
+++ b/src/main/java/gollorum/signpost/minecraft/crafting/CutWaystoneRecipe.java
@@ -11,6 +11,7 @@ import net.minecraft.world.item.crafting.SingleItemRecipe;
 import net.minecraft.world.item.crafting.StonecutterRecipe;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
+import org.jetbrains.annotations.NotNull;
 
 public class CutWaystoneRecipe extends StonecutterRecipe {
 
@@ -30,6 +31,17 @@ public class CutWaystoneRecipe extends StonecutterRecipe {
         Block block = ((BlockItem)result.getItem()).getBlock();
         if(!(block instanceof ModelWaystone)) return true;
         return Config.Server.allowedWaystones.get().contains(((ModelWaystone)block).variant.name);
+    }
+
+    @Override
+    public @NotNull ItemStack assemble(@NotNull Container container) {
+        ItemStack ret = super.assemble(container);
+        ItemStack ingred = container.getItem(0);
+        if(ingred.hasTag()) ret.setTag(ret.hasTag()
+            ? ret.getTag().merge(ingred.getTag())
+            : ingred.getTag().copy()
+        );
+        return ret;
     }
 
     public static class Serializer extends SingleItemRecipe.Serializer<CutWaystoneRecipe> {

--- a/src/main/java/gollorum/signpost/minecraft/data/WaystoneRecipe.java
+++ b/src/main/java/gollorum/signpost/minecraft/data/WaystoneRecipe.java
@@ -44,7 +44,7 @@ public class WaystoneRecipe extends RecipeProvider {
             .save(consumer, new ResourceLocation(Signpost.MOD_ID, "cut_into_" + v.name));
         }
         new SingleItemRecipeBuilder(
-            RecipeSerializer.STONECUTTER,
+            RecipeRegistry.CutWaystoneSerializer.get(),
             Ingredient.of(WaystoneTag.Tag),
             WaystoneBlock.getInstance(),
             1

--- a/src/main/java/gollorum/signpost/minecraft/gui/RequestSignGui.java
+++ b/src/main/java/gollorum/signpost/minecraft/gui/RequestSignGui.java
@@ -45,7 +45,7 @@ public class RequestSignGui implements PacketHandler.Event<RequestSignGui.Packag
 		Package message, NetworkEvent.Context context
 	) {
 		Optional<Tuple<PostTile, BlockPartInstance>> TupleO = TileEntityUtils.findTileEntityClient(
-			message.tilePartInfo.dimensionKey, message.tilePartInfo.pos, PostTile.class
+			message.tilePartInfo.dimensionKey, message.tilePartInfo.pos, PostTile.getBlockEntityType()
 		).flatMap(tile -> tile.getPart(message.tilePartInfo.identifier)
 			.flatMap(part -> (part.blockPart instanceof SignBlockPart ? Optional.of(new Tuple<>(tile, part)) : Optional.empty())));
 		if (TupleO.isPresent()) {

--- a/src/main/java/gollorum/signpost/minecraft/gui/widgets/GuiBlockPartRenderer.java
+++ b/src/main/java/gollorum/signpost/minecraft/gui/widgets/GuiBlockPartRenderer.java
@@ -1,7 +1,7 @@
 package gollorum.signpost.minecraft.gui.widgets;
 
 import com.mojang.blaze3d.vertex.PoseStack;
-import gollorum.signpost.blockpartdata.types.renderers.BlockPartRenderer;
+import gollorum.signpost.blockpartdata.types.BlockPartRenderer;
 import gollorum.signpost.minecraft.gui.utils.Point;
 import gollorum.signpost.minecraft.rendering.RenderingUtil;
 import gollorum.signpost.utils.BlockPartInstance;

--- a/src/main/java/gollorum/signpost/minecraft/items/Brush.java
+++ b/src/main/java/gollorum/signpost/minecraft/items/Brush.java
@@ -19,7 +19,7 @@ public class Brush extends TieredItem {
 
     @Override
     public InteractionResult useOn(UseOnContext context) {
-        return TileEntityUtils.findTileEntity(context.getLevel(), context.getClickedPos(), PostTile.class)
+        return context.getLevel().getBlockEntity(context.getClickedPos(), PostTile.getBlockEntityType())
             .map(tile -> PostBlock.onActivate(tile, context.getLevel(), context.getPlayer(), context.getHand()))
             .orElse(InteractionResult.PASS);
     }

--- a/src/main/java/gollorum/signpost/minecraft/items/WaystoneItem.java
+++ b/src/main/java/gollorum/signpost/minecraft/items/WaystoneItem.java
@@ -1,0 +1,37 @@
+package gollorum.signpost.minecraft.items;
+
+import gollorum.signpost.WaystoneHandle;
+import gollorum.signpost.minecraft.block.ModelWaystone;
+import gollorum.signpost.minecraft.block.WaystoneBlock;
+import gollorum.signpost.minecraft.utils.LangKeys;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+public class WaystoneItem extends BlockItem {
+
+    public WaystoneItem(WaystoneBlock waystone, Properties properties) {
+        super(waystone, properties);
+    }
+
+    public WaystoneItem(ModelWaystone waystone, Properties properties) {
+        super(waystone, properties);
+    }
+
+    @Override
+    public void appendHoverText(@NotNull ItemStack stack, @Nullable Level level, @NotNull List<Component> hoverText, @NotNull TooltipFlag flag) {
+        super.appendHoverText(stack, level, hoverText, flag);
+
+        if(stack.hasTag() && stack.getTag().contains("Handle")) {
+            hoverText.add(Component.translatable(LangKeys.waystoneHasId));
+            if(flag.isAdvanced()) hoverText.add(Component.translatable(LangKeys.waystoneId,
+                WaystoneHandle.Vanilla.Serializer.read(stack.getTag().getCompound("Handle")).id.toString()));
+        }
+    }
+}

--- a/src/main/java/gollorum/signpost/minecraft/items/Wrench.java
+++ b/src/main/java/gollorum/signpost/minecraft/items/Wrench.java
@@ -19,7 +19,7 @@ public class Wrench extends TieredItem {
 
     @Override
     public InteractionResult useOn(UseOnContext context) {
-        return TileEntityUtils.findTileEntity(context.getLevel(), context.getClickedPos(), PostTile.class)
+        return context.getLevel().getBlockEntity(context.getClickedPos(), PostTile.getBlockEntityType())
             .map(tile -> PostBlock.onActivate(tile, context.getLevel(), context.getPlayer(), context.getHand()))
             .orElse(InteractionResult.PASS);
     }

--- a/src/main/java/gollorum/signpost/minecraft/registry/ItemRegistry.java
+++ b/src/main/java/gollorum/signpost/minecraft/registry/ItemRegistry.java
@@ -5,6 +5,7 @@ import gollorum.signpost.minecraft.block.PostBlock;
 import gollorum.signpost.minecraft.block.WaystoneBlock;
 import gollorum.signpost.minecraft.items.Brush;
 import gollorum.signpost.minecraft.items.PostItem;
+import gollorum.signpost.minecraft.items.WaystoneItem;
 import gollorum.signpost.minecraft.items.Wrench;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.CreativeModeTab;
@@ -33,7 +34,7 @@ public class ItemRegistry {
 
     private static final RegistryObject<Item> WAYSTONE_ITEM =
         REGISTER.register(WaystoneBlock.REGISTRY_NAME,
-            () -> new BlockItem(WaystoneBlock.getInstance(), new Item.Properties().tab(ITEM_GROUP)));
+            () -> new WaystoneItem(WaystoneBlock.getInstance(), new Item.Properties().tab(ITEM_GROUP)));
 
     private static final List<RegistryObject<Item>> ModelWaystoneItems =
         ModelWaystone.variants.stream()
@@ -58,7 +59,7 @@ public class ItemRegistry {
     private static RegistryObject<Item> registerModelWaystoneItem(ModelWaystone.Variant variant){
         return REGISTER.register(
             variant.registryName,
-            () -> new BlockItem(variant.getBlock(), new Item.Properties().tab(ITEM_GROUP)));
+            () -> new WaystoneItem(variant.getBlock(), new Item.Properties().tab(ITEM_GROUP)));
     }
 
     public static void register(IEventBus bus){

--- a/src/main/java/gollorum/signpost/minecraft/registry/LootItemConditionRegistry.java
+++ b/src/main/java/gollorum/signpost/minecraft/registry/LootItemConditionRegistry.java
@@ -1,0 +1,23 @@
+package gollorum.signpost.minecraft.registry;
+
+import gollorum.signpost.Signpost;
+import gollorum.signpost.minecraft.storage.loot.PermissionCheck;
+import net.minecraft.core.Registry;
+import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.RegistryObject;
+
+public class LootItemConditionRegistry {
+
+    private static final DeferredRegister<LootItemConditionType> Register =
+        DeferredRegister.create(Registry.LOOT_ITEM_REGISTRY, Signpost.MOD_ID);
+
+    public static final RegistryObject<LootItemConditionType> permissionCheck =
+        Register.register("permission_check", PermissionCheck::createConditionType);
+
+    public static void register(IEventBus bus){
+        Register.register(bus);
+    }
+
+}

--- a/src/main/java/gollorum/signpost/minecraft/registry/NbtProviderRegistry.java
+++ b/src/main/java/gollorum/signpost/minecraft/registry/NbtProviderRegistry.java
@@ -1,0 +1,23 @@
+package gollorum.signpost.minecraft.registry;
+
+import gollorum.signpost.Signpost;
+import gollorum.signpost.minecraft.storage.loot.RegisteredWaystoneLootNbtProvider;
+import net.minecraft.core.Registry;
+import net.minecraft.world.level.storage.loot.providers.nbt.LootNbtProviderType;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.RegistryObject;
+
+public class NbtProviderRegistry {
+
+    private static final DeferredRegister<LootNbtProviderType> Register =
+        DeferredRegister.create(Registry.LOOT_NBT_PROVIDER_REGISTRY, Signpost.MOD_ID);
+
+    public static final RegistryObject<LootNbtProviderType> RegisteredWaystone =
+        Register.register("waystone", RegisteredWaystoneLootNbtProvider::createProviderType);
+
+    public static void register(IEventBus bus){
+        Register.register(bus);
+    }
+
+}

--- a/src/main/java/gollorum/signpost/minecraft/rendering/PostItemRenderer.java
+++ b/src/main/java/gollorum/signpost/minecraft/rendering/PostItemRenderer.java
@@ -4,12 +4,14 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import gollorum.signpost.Signpost;
 import gollorum.signpost.blockpartdata.types.PostBlockPart;
 import gollorum.signpost.blockpartdata.types.SmallWideSignBlockPart;
-import gollorum.signpost.blockpartdata.types.renderers.BlockPartRenderer;
+import gollorum.signpost.blockpartdata.types.BlockPartRenderer;
 import gollorum.signpost.minecraft.block.PostBlock;
 import gollorum.signpost.minecraft.block.tiles.PostTile;
 import gollorum.signpost.minecraft.gui.utils.Colors;
 import gollorum.signpost.utils.BlockPartInstance;
+import gollorum.signpost.utils.NameProvider;
 import gollorum.signpost.utils.math.Angle;
+import gollorum.signpost.utils.AngleProvider;
 import gollorum.signpost.utils.math.geometry.Vector3;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
@@ -48,8 +50,8 @@ public class PostItemRenderer extends BlockEntityWithoutLevelRenderer {
             PostBlock.ModelType type = ((PostBlock)((BlockItem) stack.getItem()).getBlock()).type;
             parts.add(new BlockPartInstance(new PostBlockPart(type.postTexture), Vector3.ZERO));
             parts.add(new BlockPartInstance(new SmallWideSignBlockPart(
-                Angle.fromDegrees(180), "", true, type.mainTexture, type.secondaryTexture, Optional.empty(),
-                Colors.white, Optional.empty(), ItemStack.EMPTY, type, false
+                new AngleProvider.Literal(Angle.fromDegrees(180)), new NameProvider.Literal(""), true, type.mainTexture, type.secondaryTexture,
+                Optional.empty(), Colors.white, Optional.empty(), ItemStack.EMPTY, type, false
             ), new Vector3(0, 0.75f, 0)));
         }
 

--- a/src/main/java/gollorum/signpost/minecraft/rendering/PostRenderer.java
+++ b/src/main/java/gollorum/signpost/minecraft/rendering/PostRenderer.java
@@ -2,7 +2,7 @@ package gollorum.signpost.minecraft.rendering;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import gollorum.signpost.blockpartdata.types.PostBlockPart;
-import gollorum.signpost.blockpartdata.types.renderers.BlockPartRenderer;
+import gollorum.signpost.blockpartdata.types.BlockPartRenderer;
 import gollorum.signpost.minecraft.block.tiles.PostTile;
 import gollorum.signpost.utils.BlockPartInstance;
 import net.minecraft.client.Minecraft;

--- a/src/main/java/gollorum/signpost/minecraft/storage/loot/PermissionCheck.java
+++ b/src/main/java/gollorum/signpost/minecraft/storage/loot/PermissionCheck.java
@@ -1,0 +1,86 @@
+package gollorum.signpost.minecraft.storage.loot;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import gollorum.signpost.PlayerHandle;
+import gollorum.signpost.minecraft.block.tiles.WaystoneTile;
+import gollorum.signpost.minecraft.config.Config;
+import gollorum.signpost.minecraft.registry.LootItemConditionRegistry;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.storage.loot.LootContext;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
+import net.minecraft.world.level.storage.loot.predicates.LootItemCondition;
+import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+
+public final class PermissionCheck implements LootItemCondition {
+
+    public static enum Type {
+        CanPickWaystone("pick_waystone");
+
+        public final String name;
+        Type(String name) { this.name = name; }
+    }
+
+    public static LootItemConditionType createConditionType() { return new LootItemConditionType(new Serializer()); }
+
+    private final Type type;
+
+    public PermissionCheck(Type type) {
+        this.type = type;
+    }
+
+    @Override
+    public LootItemConditionType getType() {
+        return LootItemConditionRegistry.permissionCheck.get();
+    }
+
+    @Override
+    public boolean test(LootContext lootContext) {
+        if(!lootContext.hasParam(LootContextParams.THIS_ENTITY)) return true;
+        Entity thisEntity = lootContext.getParam(LootContextParams.THIS_ENTITY);
+        if(thisEntity.hasPermissions(Config.Server.permissions.pickUnownedWaystonePermissionLevel.get())) return true;
+
+        if(!lootContext.hasParam(LootContextParams.BLOCK_ENTITY)) return false;
+        BlockEntity blockEntity = lootContext.getParam(LootContextParams.BLOCK_ENTITY);
+        if(!(blockEntity instanceof WaystoneTile)) return false;
+        WaystoneTile waystoneTile = (WaystoneTile) blockEntity;
+        return waystoneTile.getWaystoneOwner()
+            .map(owner -> owner.equals(PlayerHandle.from(thisEntity)))
+            .orElse(true);
+    }
+
+    public static class Builder implements LootItemCondition.Builder {
+
+        private final Type type;
+
+        public Builder(Type type) {
+            this.type = type;
+        }
+
+        @Override
+        public @NotNull PermissionCheck build() {
+            return new PermissionCheck(type);
+        }
+    }
+
+    private static final class Serializer implements net.minecraft.world.level.storage.loot.Serializer<PermissionCheck> {
+
+        @Override
+        public void serialize(JsonObject jsonObject, PermissionCheck instance, JsonSerializationContext context) {
+            jsonObject.addProperty("type", instance.type.name);
+        }
+
+        @Override
+        public PermissionCheck deserialize(JsonObject jsonObject, JsonDeserializationContext context) {
+            String type = GsonHelper.getAsString(jsonObject, "type");
+            return new PermissionCheck(Arrays.stream(Type.values()).filter(t -> t.name.equals(type)).findFirst().get());
+        }
+    }
+
+}

--- a/src/main/java/gollorum/signpost/minecraft/storage/loot/RegisteredWaystoneLootNbtProvider.java
+++ b/src/main/java/gollorum/signpost/minecraft/storage/loot/RegisteredWaystoneLootNbtProvider.java
@@ -1,0 +1,72 @@
+package gollorum.signpost.minecraft.storage.loot;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import gollorum.signpost.WaystoneHandle;
+import gollorum.signpost.WaystoneLibrary;
+import gollorum.signpost.minecraft.block.tiles.WaystoneTile;
+import gollorum.signpost.minecraft.registry.NbtProviderRegistry;
+import gollorum.signpost.utils.WorldLocation;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.storage.loot.LootContext;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParam;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
+import net.minecraft.world.level.storage.loot.providers.nbt.LootNbtProviderType;
+import net.minecraft.world.level.storage.loot.providers.nbt.NbtProvider;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
+import java.util.Set;
+
+public final class RegisteredWaystoneLootNbtProvider implements NbtProvider {
+
+    public static LootNbtProviderType createProviderType() { return new LootNbtProviderType(new Serializer()); };
+
+    @Nullable
+    @Override
+    public Tag get(LootContext context) {
+        BlockEntity blockEntity = context.getParam(LootContextParams.BLOCK_ENTITY);
+        if(blockEntity instanceof WaystoneTile) {
+            WaystoneTile waystoneTile = (WaystoneTile) blockEntity;
+            CompoundTag ret = new CompoundTag();
+            Optional<WaystoneHandle.Vanilla> handle = waystoneTile.getHandle()
+                .or(() -> WaystoneLibrary.getInstance().getHandleByLocation(new WorldLocation(waystoneTile.getBlockPos(), waystoneTile.getLevel())));
+            handle.ifPresent(h -> ret.put("Handle", WaystoneHandle.Vanilla.Serializer.write(h)));
+            waystoneTile.getName()
+                .or(() -> handle.flatMap(h -> WaystoneLibrary.getInstance().getData(h).map(d -> d.name)))
+                .ifPresent(n -> {
+                    CompoundTag displayTag = new CompoundTag();
+                    displayTag.putString("Name", Component.Serializer.toJson(Component.literal(n)));
+                    ret.put("display", displayTag);
+                });
+            return ret;
+        } else return null;
+    }
+
+    @Override
+    public Set<LootContextParam<?>> getReferencedContextParams() {
+        return ImmutableSet.of(LootContextParams.BLOCK_ENTITY);
+    }
+
+    @Override
+    public LootNbtProviderType getType() {
+        return NbtProviderRegistry.RegisteredWaystone.get();
+    }
+
+    public static final class Serializer implements net.minecraft.world.level.storage.loot.Serializer<RegisteredWaystoneLootNbtProvider> {
+
+        @Override
+        public void serialize(JsonObject jsonObject, RegisteredWaystoneLootNbtProvider instance, JsonSerializationContext context) { }
+
+        @Override
+        public RegisteredWaystoneLootNbtProvider deserialize(JsonObject jsonObject, JsonDeserializationContext context) {
+            return new RegisteredWaystoneLootNbtProvider();
+        }
+    }
+
+}

--- a/src/main/java/gollorum/signpost/minecraft/utils/LangKeys.java
+++ b/src/main/java/gollorum/signpost/minecraft/utils/LangKeys.java
@@ -42,4 +42,9 @@ public class LangKeys {
 	public static final String unlimitedSignpostsOther = "signpost.unlimited_signposts_other";
 
 	public static final String noTeleportWaystoneMod = "signpost.no_teleport_waystones_mod";
+
+    public static final String waystoneHasId = "item.signpost.waystone_has_id";
+    public static final String waystoneId = "item.signpost.waystone_id";
+    public static final String duplicateWaystoneId = "signpost.duplicate_waystone_id";
+    public static final String duplicateWaystoneName = "signpost.duplicate_waystone_name";
 }

--- a/src/main/java/gollorum/signpost/minecraft/utils/TileEntityUtils.java
+++ b/src/main/java/gollorum/signpost/minecraft/utils/TileEntityUtils.java
@@ -13,25 +13,19 @@ import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
 
 import java.util.Optional;
 import java.util.function.Consumer;
 
 public class TileEntityUtils {
 
-    public static <T> Optional<T> findTileEntity(BlockGetter world, BlockPos pos, Class<T> c){
-        BlockEntity tileEntity = world.getBlockEntity(pos);
-        if(tileEntity != null && c.isAssignableFrom(tileEntity.getClass())){
-            return Optional.of((T) tileEntity);
-        } else return Optional.empty();
+    public static <T extends BlockEntity> void delayUntilTileEntityExists(LevelAccessor world, BlockPos pos, BlockEntityType<T> c, Consumer<T> action, int timeout, Optional<Runnable> onTimeOut) {
+        Delay.untilIsPresent(() -> world.getBlockEntity(pos, c), action, timeout, world.isClientSide(), onTimeOut);
     }
 
-    public static <T> void delayUntilTileEntityExists(LevelAccessor world, BlockPos pos, Class<T> c, Consumer<T> action, int timeout, Optional<Runnable> onTimeOut) {
-        Delay.untilIsPresent(() -> findTileEntity(world, pos, c), action, timeout, world.isClientSide(), onTimeOut);
-    }
-
-    public static <T> Optional<T> findTileEntity(ResourceLocation dimensionKeyLocation, boolean isRemote, BlockPos blockPos, Class<T> c){
-        return findWorld(dimensionKeyLocation, isRemote).flatMap(world -> findTileEntity(world, blockPos, c));
+    public static <T extends BlockEntity> Optional<T> findTileEntity(ResourceLocation dimensionKeyLocation, boolean isRemote, BlockPos blockPos, BlockEntityType<T> c){
+        return findWorld(dimensionKeyLocation, isRemote).flatMap(world -> world.getBlockEntity(blockPos, c));
     }
 
     public static Optional<Level> findWorld(ResourceLocation dimensionKeyLocation, boolean isClient) {
@@ -58,13 +52,22 @@ public class TileEntityUtils {
             .flatMap(tile -> c.isAssignableFrom(tile.getClass()) ? Optional.of((T)tile) : Optional.empty());
     }
 
+    public static <T extends BlockEntity> Optional<T> findTileEntityAt(WorldLocation location, BlockEntityType<T> c, boolean onClient) {
+        return toWorld(location.world, onClient)
+            .flatMap(w -> w.getBlockEntity(location.blockPos, c));
+    }
+
     public static <T> void delayUntilTileEntityExistsAt(WorldLocation location, Class<T> c, Consumer<T> action, int timeout, boolean onClient, Optional<Runnable> onTimeOut) {
         Delay.untilIsPresent(() -> findTileEntityAt(location, c, onClient), action, timeout, onClient, onTimeOut);
     }
 
-    public static <T> Optional<T> findTileEntityClient(ResourceLocation dimensionKeyLocation, BlockPos pos, Class<T> c){
+    public static <T extends BlockEntity> void delayUntilTileEntityExistsAt(WorldLocation location, BlockEntityType<T> c, Consumer<T> action, int timeout, boolean onClient, Optional<Runnable> onTimeOut) {
+        Delay.untilIsPresent(() -> findTileEntityAt(location, c, onClient), action, timeout, onClient, onTimeOut);
+    }
+
+    public static <T extends BlockEntity> Optional<T> findTileEntityClient(ResourceLocation dimensionKeyLocation, BlockPos pos, BlockEntityType<T> c){
         return Minecraft.getInstance().level.dimension().location().equals(dimensionKeyLocation)
-            ? findTileEntity(Minecraft.getInstance().level, pos, c)
+            ? Minecraft.getInstance().level.getBlockEntity(pos, c)
             : Optional.empty();
     }
 

--- a/src/main/java/gollorum/signpost/minecraft/worldgen/SignpostJigsawPiece.java
+++ b/src/main/java/gollorum/signpost/minecraft/worldgen/SignpostJigsawPiece.java
@@ -18,9 +18,7 @@ import gollorum.signpost.minecraft.block.tiles.PostTile;
 import gollorum.signpost.minecraft.config.Config;
 import gollorum.signpost.minecraft.gui.utils.Colors;
 import gollorum.signpost.minecraft.utils.TileEntityUtils;
-import gollorum.signpost.utils.BlockPartInstance;
-import gollorum.signpost.utils.Tuple;
-import gollorum.signpost.utils.WaystoneData;
+import gollorum.signpost.utils.*;
 import gollorum.signpost.utils.math.Angle;
 import gollorum.signpost.utils.math.geometry.Vector3;
 import net.minecraft.core.BlockPos;
@@ -226,7 +224,7 @@ public class SignpostJigsawPiece extends SinglePoolElement {
 			tile.addPart(
 				new BlockPartInstance(
 					new SmallWideSignBlockPart(
-						rotation, targetData.name, shouldFlip(facing, rotation),
+						new AngleProvider.WaystoneTarget(rotation), new NameProvider.WaystoneTarget(targetData.name), shouldFlip(facing, rotation),
 						tile.modelType.mainTexture, tile.modelType.secondaryTexture,
 						overlayFor(world, tilePos), Colors.black, Optional.of(target._2),
 						ItemStack.EMPTY, tile.modelType, false
@@ -261,7 +259,7 @@ public class SignpostJigsawPiece extends SinglePoolElement {
 		onTileFetched.add(tile -> tile.addPart(
 			new BlockPartInstance(
 				new SmallShortSignBlockPart(
-					rotation, targetData.name, shouldFlip,
+					new AngleProvider.WaystoneTarget(rotation), new NameProvider.WaystoneTarget(targetData.name), shouldFlip,
 					tile.modelType.mainTexture, tile.modelType.secondaryTexture,
 					overlay, Colors.black, Optional.of(target._2),
 					ItemStack.EMPTY, tile.modelType, false
@@ -291,7 +289,7 @@ public class SignpostJigsawPiece extends SinglePoolElement {
 			onTileFetched.add(tile -> tile.addPart(
 				new BlockPartInstance(
 					new SmallShortSignBlockPart(
-						secondRotation, secondTargetData.name, shouldSecondFlip,
+						new AngleProvider.WaystoneTarget(secondRotation), new NameProvider.WaystoneTarget(secondTargetData.name), shouldSecondFlip,
 						tile.modelType.mainTexture, tile.modelType.secondaryTexture,
 						overlay, Colors.black, Optional.of(secondTargetHandle),
 						ItemStack.EMPTY, tile.modelType, false

--- a/src/main/java/gollorum/signpost/minecraft/worldgen/SignpostJigsawPiece.java
+++ b/src/main/java/gollorum/signpost/minecraft/worldgen/SignpostJigsawPiece.java
@@ -180,7 +180,7 @@ public class SignpostJigsawPiece extends SinglePoolElement {
 		Tuple<Collection<WaystoneHandle.Vanilla>, Consumer<PostTile>> lowerSignResult = makeSign(random, facing, world, upperPos,
 			possibleTargets, 0.25f
 		);
-		TileEntityUtils.delayUntilTileEntityExists(world.getLevel(), upperPos, PostTile.class, tile -> {
+		TileEntityUtils.delayUntilTileEntityExists(world.getLevel(), upperPos, PostTile.getBlockEntityType(), tile -> {
 			upperSignResult._2.accept(tile);
 			lowerSignResult._2.accept(tile);
 			tile.setChanged();

--- a/src/main/java/gollorum/signpost/networking/PacketHandler.java
+++ b/src/main/java/gollorum/signpost/networking/PacketHandler.java
@@ -32,6 +32,7 @@ public class PacketHandler {
         new PostTile.PartAddedEvent(),
         new PostTile.PartMutatedEvent(),
         new PostTile.PartRemovedEvent(),
+        new PostTile.UpdateAllPartsEvent(),
         new Teleport.Request(),
         new Teleport.RequestGui(),
         new RequestSignGui(),

--- a/src/main/java/gollorum/signpost/utils/AngleProvider.java
+++ b/src/main/java/gollorum/signpost/utils/AngleProvider.java
@@ -1,0 +1,73 @@
+package gollorum.signpost.utils;
+
+import gollorum.signpost.utils.math.Angle;
+import gollorum.signpost.utils.serialization.CompoundSerializable;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.Tag;
+
+public interface AngleProvider {
+
+    Angle get();
+
+    public static final class Literal implements AngleProvider {
+        private final Angle angle;
+
+        public Literal(Angle angle) { this.angle = angle; }
+
+        @Override
+        public Angle get() { return angle; }
+    }
+
+    public static final class WaystoneTarget implements AngleProvider {
+
+        private Angle cachedAngle;
+        public void setCachedAngle(Angle cachedAngle) { this.cachedAngle = cachedAngle; }
+
+        public WaystoneTarget(Angle cachedAngle) {
+            this.cachedAngle = cachedAngle;
+        }
+
+        @Override
+        public Angle get() { return cachedAngle; }
+    }
+
+    public static AngleProvider fetchFrom(CompoundTag tag) {
+        return Serializer.isContainedIn(tag)
+            ? Serializer.read(tag)
+            : new Literal(Angle.Serializer.read(tag));
+    }
+    public static final CompoundSerializable<AngleProvider> Serializer = new CompoundSerializable<>() {
+        @Override
+        public Class<AngleProvider> getTargetClass() {
+            return AngleProvider.class;
+        }
+
+        @Override
+        public CompoundTag write(AngleProvider angleProvider, CompoundTag compound) {
+            if (angleProvider instanceof Literal) {
+                compound.putString("type", "literal");
+                compound.put("angle", Angle.Serializer.write(((Literal) angleProvider).angle));
+            } else if (angleProvider instanceof WaystoneTarget) {
+                compound.putString("type", "waystone");
+                compound.put("cachedAngle", Angle.Serializer.write(angleProvider.get()));
+            } else throw new RuntimeException("Invalid angle provider type " + angleProvider.getClass());
+            return compound;
+        }
+
+        @Override
+        public boolean isContainedIn(CompoundTag compound) {
+            return compound.contains("type") || Angle.Serializer.isContainedIn(compound);
+        }
+
+        @Override
+        public AngleProvider read(CompoundTag compound) {
+            String type = compound.getString("type");
+            if (type.equals("literal")) return new Literal(Angle.Serializer.read(compound.getCompound("angle")));
+            else if (type.equals("waystone")) return new WaystoneTarget(
+                Angle.Serializer.read(compound.getCompound("cachedAngle"))
+            );
+            else if(Angle.Serializer.isContainedIn(compound)) return new Literal(Angle.Serializer.read(compound));
+            else throw new RuntimeException("Invalid angle provider type " + type);
+        }
+    };
+}

--- a/src/main/java/gollorum/signpost/utils/BlockPart.java
+++ b/src/main/java/gollorum/signpost/utils/BlockPart.java
@@ -28,6 +28,7 @@ public interface BlockPart<T extends BlockPart<T>> extends Interactable {
 
     Collection<ItemStack> getDrops(PostTile tile);
 
+    default void attachTo(PostTile tile) {}
     default void removeFrom(PostTile tile) {}
 
     Collection<ResourceLocation> getAllTextures();

--- a/src/main/java/gollorum/signpost/utils/EventDispatcher.java
+++ b/src/main/java/gollorum/signpost/utils/EventDispatcher.java
@@ -2,33 +2,75 @@ package gollorum.signpost.utils;
 
 import javax.annotation.Nonnull;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 
 public interface EventDispatcher<Event> {
 
-    boolean addListener(@Nonnull Consumer<Event> listener);
+    public interface Listener<Event> {
+        /***
+         Returns whether the listener is done and should be removed.
+        */
+        boolean accept(Event event);
+    }
 
-    boolean removeListener(@Nonnull Consumer<Event> listener);
+    class ConsumerWrapper<Event> implements Listener<Event> {
+        private final Consumer<Event> consumer;
+
+        public ConsumerWrapper(Consumer<Event> consumer) {
+            this.consumer = consumer;
+        }
+
+        @Override
+        public boolean accept(Event event) {
+            consumer.accept(event);
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            return consumer.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return this == obj ||
+                (obj instanceof EventDispatcher.ConsumerWrapper<?> && consumer.equals(((ConsumerWrapper<?>)obj).consumer)) ||
+                consumer.equals(obj);
+        }
+    }
+
+    boolean addListener(@Nonnull Listener<Event> listener);
+    default boolean addListener(@Nonnull Consumer<Event> listener) {
+        return addListener(new ConsumerWrapper<>(listener));
+    }
+
+    boolean removeListener(@Nonnull Listener<Event> listener);
+    default boolean removeListener(@Nonnull Consumer<Event> listener) {
+        return removeListener(new ConsumerWrapper<>(listener));
+    }
 
     abstract class Impl<Event> implements EventDispatcher<Event> {
 
-        protected final Set<Consumer<Event>> listeners = new HashSet<>();
+        protected final Set<Listener<Event>> listeners = new HashSet<>();
 
-        public boolean addListener(@Nonnull Consumer<Event> listener) { return listeners.add(listener); }
+        public boolean addListener(@Nonnull Listener<Event> listener) { return listeners.add(listener); }
 
-        public boolean removeListener(@Nonnull Consumer<Event> listener) { return listeners.remove(listener); }
+        public boolean removeListener(@Nonnull Listener<Event> listener) { return listeners.remove(listener); }
 
-        protected void dispatch(Event event) { dispatch(event, new HashSet<>(listeners)); }
-
-        protected void dispatch(Event event, Set<Consumer<Event>> listeners) { listeners.forEach(listener -> listener.accept(event)); }
+        protected void dispatch(Event event, Set<Listener<Event>> listeners, boolean clearAfterwards) {
+            listeners.forEach(listener -> {
+                if(listener.accept(event) && !clearAfterwards) this.listeners.remove(listener);
+            });
+        }
 
         public static class WithPublicDispatch<Event> extends Impl<Event> {
 
             public void dispatch(Event event, boolean clearAfterwards) {
-                Set<Consumer<Event>> copyOfListeners = new HashSet<>(listeners);
+                Set<Listener<Event>> copyOfListeners = new HashSet<>(listeners);
                 if(clearAfterwards) clear();
-                super.dispatch(event, copyOfListeners);
+                super.dispatch(event, copyOfListeners, clearAfterwards);
             }
 
             public void clear() { listeners.clear(); }

--- a/src/main/java/gollorum/signpost/utils/NameProvider.java
+++ b/src/main/java/gollorum/signpost/utils/NameProvider.java
@@ -1,0 +1,85 @@
+package gollorum.signpost.utils;
+
+import gollorum.signpost.utils.serialization.CompoundSerializable;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.network.FriendlyByteBuf;
+
+public interface NameProvider {
+
+    String get();
+
+    public static final class Literal implements NameProvider {
+
+        private final String name;
+
+        @Override
+        public String get() { return name; }
+
+        public Literal(String name) { this.name = name; }
+    }
+
+    public static final class WaystoneTarget implements NameProvider {
+
+        private String cachedName;
+        public void setCachedName(String name) { cachedName = name; }
+
+        @Override
+        public String get() { return cachedName; }
+
+        public WaystoneTarget(String cachedName) { this.cachedName = cachedName; }
+    }
+
+    public static NameProvider fetchFrom(Tag tag) {
+        return tag instanceof CompoundTag && Serializer.isContainedIn((CompoundTag) tag)
+            ? Serializer.read((CompoundTag) tag)
+            : new Literal(tag.getAsString());
+    }
+    public static final CompoundSerializable<NameProvider> Serializer = new CompoundSerializable<>() {
+
+        @Override
+        public CompoundTag write(NameProvider nameProvider, CompoundTag compound) {
+            compound.putString("name", nameProvider.get());
+            compound.putString("type", nameProvider instanceof Literal ? "literal" : "waystone");
+            return compound;
+        }
+
+        @Override
+        public boolean isContainedIn(CompoundTag compound) {
+            return compound.contains("name") && compound.contains("type");
+        }
+
+        @Override
+        public NameProvider read(CompoundTag compound) {
+            String type = compound.getString("type");
+            String name = compound.getString("name");
+            return from(type, name);
+        }
+
+        @Override
+        public void write(NameProvider nameProvider, FriendlyByteBuf buffer) {
+            buffer.writeUtf(nameProvider instanceof Literal ? "literal" : "waystone");
+            buffer.writeUtf(nameProvider.get());
+        }
+
+        @Override
+        public NameProvider read(FriendlyByteBuf buffer) {
+            return from(buffer.readUtf(), buffer.readUtf());
+        }
+
+        private NameProvider from(String type, String name) {
+            switch (type) {
+                case "literal": return new Literal(name);
+                case "waystone": return new WaystoneTarget(name);
+                default: throw new RuntimeException("Invalid name provider type " + type);
+            }
+        }
+
+        @Override
+        public Class<NameProvider> getTargetClass() {
+            return NameProvider.class;
+        }
+
+    };
+
+}

--- a/src/main/java/gollorum/signpost/utils/serialization/StringSerializer.java
+++ b/src/main/java/gollorum/signpost/utils/serialization/StringSerializer.java
@@ -1,14 +1,31 @@
 package gollorum.signpost.utils.serialization;
 
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
 
-public final class StringSerializer implements BufferSerializable<String> {
+public final class StringSerializer implements CompoundSerializable<String> {
 
     public static final StringSerializer instance = new StringSerializer();
 
     @Override
     public Class<String> getTargetClass() {
         return String.class;
+    }
+
+    @Override
+    public CompoundTag write(String s, CompoundTag compound) {
+        compound.putString("String", s);
+        return compound;
+    }
+
+    @Override
+    public boolean isContainedIn(CompoundTag compound) {
+        return compound.contains("String");
+    }
+
+    @Override
+    public String read(CompoundTag compound) {
+        return compound.getString("String");
     }
 
     @Override

--- a/src/main/resources/assets/signpost/lang/de_de.json
+++ b/src/main/resources/assets/signpost/lang/de_de.json
@@ -24,6 +24,8 @@
 
   "item.signpost.tool": "Wegweiserdrehwerkzeug",
   "item.signpost.brush": "Wegweiserpinsel",
+  "item.signpost.waystone_has_id": "Besitzt eine ID. Es könnte Wegweiser geben, die hierin zeigen werden.",
+  "item.signpost.waystone_id": "ID: %s",
 
   "gui.signpost.sign_gui_title": "Schild hinzufügen oder editieren",
   "gui.signpost.confirm_teleport_gui_title": "Teleport bestätigen",
@@ -36,7 +38,7 @@
   "gui.signpost.rotation_player": "%d (Blickwinkel des Spielers)",
   "gui.signpost.main_material": "Vorderseite",
   "gui.signpost.secondary_material": "Rückseite / Rand",
-  "gui.signpost.unknownWaystone": "Unbekannter Wegweiser",
+  "gui.signpost.unknownWaystone": "Fehlender Wegstein",
 
   "signpost.discovered": "Du kannst mit Wegweisern nun nach %s reisen.",
   "signpost.not_discovered": "Du hast %s noch nicht entdeckt",
@@ -47,6 +49,8 @@
 
   "signpost.no_permission_to_edit_waystone": "Du bist nicht berechtigt, diesen Wegstein zu ändern.",
   "signpost.no_permission_to_edit_signpost": "Du bist nicht berechtigt, diesen Wegweiser zu ändern.",
+  "signpost.duplicate_waystone_id": "Es existiert bereits ein Wegstein mit dieser ID.",
+  "signpost.duplicate_waystone_name": "Es existiert bereits ein Wegstein \"%s\".",
 
   "signpost.no_more_waystones": "Du darfst keine weiteren Wegsteine platzieren.",
   "signpost.no_more_signposts": "Du darfst keine weiteren Wegweiser platzieren.",

--- a/src/main/resources/assets/signpost/lang/en_us.json
+++ b/src/main/resources/assets/signpost/lang/en_us.json
@@ -24,6 +24,8 @@
 
   "item.signpost.tool": "Sign angle wrench",
   "item.signpost.brush": "Signpost paint brush",
+  "item.signpost.waystone_has_id": "Has an ID. There might be signposts that will point to this.",
+  "item.signpost.waystone_id": "ID: %s",
 
   "gui.signpost.sign_gui_title": "Add or edit sign",
   "gui.signpost.confirm_teleport_gui_title": "Confirm teleport",
@@ -36,7 +38,7 @@
   "gui.signpost.rotation_player": "%d (face the player)",
   "gui.signpost.main_material": "Front",
   "gui.signpost.secondary_material": "Back / Rim",
-  "gui.signpost.unknownWaystone": "Unknown Waystone",
+  "gui.signpost.unknownWaystone": "Missing Waystone",
 
   "signpost.discovered": "You can now travel to %s using sign posts.",
   "signpost.not_discovered": "You have not yet discovered %s",
@@ -47,6 +49,8 @@
 
   "signpost.no_permission_to_edit_waystone": "You do not have permission to edit this waystone.",
   "signpost.no_permission_to_edit_signpost": "You do not have permission to edit this signpost.",
+  "signpost.duplicate_waystone_id": "A waystone with this ID already exists.",
+  "signpost.duplicate_waystone_name": "A waystone \"%s\" already exists.",
 
   "signpost.no_more_waystones": "You don't have permission to place more waystones.",
   "signpost.no_more_signposts": "You don't have permission to place more signposts.",


### PR DESCRIPTION
You can now loot waystones with silk touch (or creative pick), which makes them remember their name and internal id.
When this item is placed and there is no other existing waystone with this name or id, all signs that pointed to the old waystone are updated. This makes it possible to move waystones or give them a new shape in the stonecutter without losing the sign connections.
Moving a waystone rotates the signs such that they still point to it (only works if the sign was configured to directly point at the waystone while this update was installed).
Editing a waystone's name now also updates the text on signs pointing to them (only works if the sign text was set exactly to the old name while this update was installed).