### PR TITLE
Fix NullPointerException when joining a server

### DIFF
--- a/src/main/java/gollorum/signpost/blockpartdata/types/renderers/BlockPartWaystoneUpdateListener.java
+++ b/src/main/java/gollorum/signpost/blockpartdata/types/renderers/BlockPartWaystoneUpdateListener.java
@@ -13,7 +13,12 @@ import java.util.function.Consumer;
 public final class BlockPartWaystoneUpdateListener {
 
     private static BlockPartWaystoneUpdateListener instance;
-    public static BlockPartWaystoneUpdateListener getInstance() { return instance; }
+    public static BlockPartWaystoneUpdateListener getInstance() { 
+        if (instance == null) {
+            instance = new BlockPartWaystoneUpdateListener();
+        }
+        return instance; 
+    }
 
     private final WeakHashMap<BlockPart<?>, BiConsumer<BlockPart<?>, WaystoneUpdatedEvent>> listeners = new WeakHashMap<>();
 
@@ -25,7 +30,7 @@ public final class BlockPartWaystoneUpdateListener {
 
     public static void initialize() {
         WaystoneLibrary.onInitializeDo.addListener(lib -> {
-            instance = new BlockPartWaystoneUpdateListener();
+            instance = getInstance();
             lib.updateEventDispatcher.addListener(event -> {
                 for (Map.Entry<BlockPart<?>, BiConsumer<BlockPart<?>, WaystoneUpdatedEvent>> entry : instance.listeners.entrySet().stream().toList())
                     entry.getValue().accept(entry.getKey(), event);


### PR DESCRIPTION
I had an issue where joining a multiplayer server gets the game stuck at the "Loading Terrain..." screen, which I found out is caused by a NullPointerException at the `getInstance()` method on the `BlockPartWaystoneUpdateListener` static instance.

The fix made the static instance initialize whenever it is needed for the first time, so it can't be null anymore.

---

Below is the screen that I got stuck at, and the error log it produces for reference.

![](https://github.com/Gollorum/Signpost/assets/37289650/071536bf-a267-4655-a54e-743b7aeb9dd7)

```
[01:44:31] [Render thread/ERROR]: Error executing task on Client
java.lang.NullPointerException: Cannot invoke "gollorum.signpost.blockpartdata.types.renderers.BlockPartWaystoneUpdateListener.addListener(gollorum.signpost.utils.BlockPart, java.util.function.BiConsumer)" because the return value of "gollorum.signpost.blockpartdata.types.renderers.BlockPartWaystoneUpdateListener.getInstance()" is null
	at gollorum.signpost.blockpartdata.types.SignBlockPart.attachTo(SignBlockPart.java:195) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at gollorum.signpost.minecraft.block.tiles.PostTile.addPart(PostTile.java:124) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at gollorum.signpost.minecraft.block.tiles.PostTile.addPart(PostTile.java:120) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at gollorum.signpost.minecraft.block.tiles.PostTile.readParts(PostTile.java:252) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at gollorum.signpost.minecraft.block.tiles.PostTile.readSelf(PostTile.java:267) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at gollorum.signpost.minecraft.block.tiles.PostTile.m_142466_(PostTile.java:223) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at net.minecraftforge.common.extensions.IForgeBlockEntity.handleUpdateTag(IForgeBlockEntity.java:72) ~[forge-1.18.2-40.2.14-universal.jar%23201!/:?]
	at gollorum.signpost.minecraft.block.tiles.PostTile.handleUpdateTag(PostTile.java:305) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at net.minecraft.world.level.chunk.LevelChunk.m_187967_(LevelChunk.java:444) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.network.protocol.game.ClientboundLevelChunkPacketData.m_195674_(ClientboundLevelChunkPacketData.java:107) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.network.protocol.game.ClientboundLevelChunkPacketData.m_195660_(ClientboundLevelChunkPacketData.java:96) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.world.level.chunk.LevelChunk.m_187971_(LevelChunk.java:441) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.multiplayer.ClientChunkCache.m_194116_(ClientChunkCache.java:97) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.multiplayer.ClientPacketListener.m_194198_(ClientPacketListener.java:605) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.multiplayer.ClientPacketListener.m_183388_(ClientPacketListener.java:600) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket.m_5797_(ClientboundLevelChunkWithLightPacket.java:45) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket.m_5797_(ClientboundLevelChunkWithLightPacket.java:12) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.network.protocol.PacketUtils.m_131356_(PacketUtils.java:22) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.util.thread.BlockableEventLoop.m_6367_(BlockableEventLoop.java:157) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.util.thread.ReentrantBlockableEventLoop.m_6367_(ReentrantBlockableEventLoop.java:23) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.util.thread.BlockableEventLoop.m_7245_(BlockableEventLoop.java:131) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.util.thread.BlockableEventLoop.m_18699_(BlockableEventLoop.java:116) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.Minecraft.m_91383_(Minecraft.java:1015) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.Minecraft.m_91374_(Minecraft.java:665) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.main.Main.main(Main.java:205) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source) ~[?:?]
	at java.lang.reflect.Method.invoke(Unknown Source) ~[?:?]
	at net.minecraftforge.fml.loading.targets.CommonClientLaunchHandler.lambda$launchService$0(CommonClientLaunchHandler.java:31) ~[fmlloader-1.18.2-40.2.14.jar%2318!/:?]
	at cpw.mods.modlauncher.LaunchServiceHandlerDecorator.launch(LaunchServiceHandlerDecorator.java:37) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:53) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:71) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.Launcher.run(Launcher.java:106) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.Launcher.main(Launcher.java:77) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:26) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:23) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.bootstraplauncher.BootstrapLauncher.main(BootstrapLauncher.java:149) [bootstraplauncher-1.0.0.jar:?]
[01:44:31] [Render thread/WARN]: defineId called for: class dev.itsmeow.betteranimalsplus.common.entity.EntityBadger from class dev.itsmeow.betteranimalsplus.imdlib.entity.EntityTypeContainer
[01:44:31] [Render thread/WARN]: defineId called for: class dev.itsmeow.betteranimalsplus.common.entity.EntityButterfly from class dev.itsmeow.betteranimalsplus.imdlib.entity.EntityTypeContainer
[01:44:31] [Render thread/WARN]: defineId called for: class dev.itsmeow.betteranimalsplus.common.entity.EntityButterfly from class dev.itsmeow.betteranimalsplus.imdlib.entity.util.EntityTypeContainerContainable
[01:44:31] [Render thread/WARN]: Received passengers for unknown entity
[01:44:31] [Render thread/ERROR]: Error executing task on Client
java.lang.NullPointerException: Cannot invoke "gollorum.signpost.blockpartdata.types.renderers.BlockPartWaystoneUpdateListener.addListener(gollorum.signpost.utils.BlockPart, java.util.function.BiConsumer)" because the return value of "gollorum.signpost.blockpartdata.types.renderers.BlockPartWaystoneUpdateListener.getInstance()" is null
	at gollorum.signpost.blockpartdata.types.SignBlockPart.attachTo(SignBlockPart.java:195) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at gollorum.signpost.minecraft.block.tiles.PostTile.addPart(PostTile.java:124) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at gollorum.signpost.minecraft.block.tiles.PostTile.addPart(PostTile.java:120) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at gollorum.signpost.minecraft.block.tiles.PostTile.readParts(PostTile.java:252) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at gollorum.signpost.minecraft.block.tiles.PostTile.readSelf(PostTile.java:267) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at gollorum.signpost.minecraft.block.tiles.PostTile.m_142466_(PostTile.java:223) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at net.minecraftforge.common.extensions.IForgeBlockEntity.handleUpdateTag(IForgeBlockEntity.java:72) ~[forge-1.18.2-40.2.14-universal.jar%23201!/:?]
	at gollorum.signpost.minecraft.block.tiles.PostTile.handleUpdateTag(PostTile.java:305) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at net.minecraft.world.level.chunk.LevelChunk.m_187967_(LevelChunk.java:444) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.network.protocol.game.ClientboundLevelChunkPacketData.m_195674_(ClientboundLevelChunkPacketData.java:107) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.network.protocol.game.ClientboundLevelChunkPacketData.m_195660_(ClientboundLevelChunkPacketData.java:96) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.world.level.chunk.LevelChunk.m_187971_(LevelChunk.java:441) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.multiplayer.ClientChunkCache.m_194116_(ClientChunkCache.java:97) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.multiplayer.ClientPacketListener.m_194198_(ClientPacketListener.java:605) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.multiplayer.ClientPacketListener.m_183388_(ClientPacketListener.java:600) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket.m_5797_(ClientboundLevelChunkWithLightPacket.java:45) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket.m_5797_(ClientboundLevelChunkWithLightPacket.java:12) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.network.protocol.PacketUtils.m_131356_(PacketUtils.java:22) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.util.thread.BlockableEventLoop.m_6367_(BlockableEventLoop.java:157) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.util.thread.ReentrantBlockableEventLoop.m_6367_(ReentrantBlockableEventLoop.java:23) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.util.thread.BlockableEventLoop.m_7245_(BlockableEventLoop.java:131) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.util.thread.BlockableEventLoop.m_18699_(BlockableEventLoop.java:116) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.Minecraft.m_91383_(Minecraft.java:1015) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.Minecraft.m_91374_(Minecraft.java:665) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.main.Main.main(Main.java:205) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source) ~[?:?]
	at java.lang.reflect.Method.invoke(Unknown Source) ~[?:?]
	at net.minecraftforge.fml.loading.targets.CommonClientLaunchHandler.lambda$launchService$0(CommonClientLaunchHandler.java:31) ~[fmlloader-1.18.2-40.2.14.jar%2318!/:?]
	at cpw.mods.modlauncher.LaunchServiceHandlerDecorator.launch(LaunchServiceHandlerDecorator.java:37) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:53) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:71) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.Launcher.run(Launcher.java:106) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.Launcher.main(Launcher.java:77) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:26) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:23) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.bootstraplauncher.BootstrapLauncher.main(BootstrapLauncher.java:149) [bootstraplauncher-1.0.0.jar:?]
[01:44:31] [Render thread/WARN]: Received passengers for unknown entity
[01:44:31] [Render thread/ERROR]: Error executing task on Client
java.lang.NullPointerException: Cannot invoke "gollorum.signpost.blockpartdata.types.renderers.BlockPartWaystoneUpdateListener.addListener(gollorum.signpost.utils.BlockPart, java.util.function.BiConsumer)" because the return value of "gollorum.signpost.blockpartdata.types.renderers.BlockPartWaystoneUpdateListener.getInstance()" is null
	at gollorum.signpost.blockpartdata.types.SignBlockPart.attachTo(SignBlockPart.java:195) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at gollorum.signpost.minecraft.block.tiles.PostTile.addPart(PostTile.java:124) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at gollorum.signpost.minecraft.block.tiles.PostTile.addPart(PostTile.java:120) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at gollorum.signpost.minecraft.block.tiles.PostTile.readParts(PostTile.java:252) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at gollorum.signpost.minecraft.block.tiles.PostTile.readSelf(PostTile.java:267) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at gollorum.signpost.minecraft.block.tiles.PostTile.m_142466_(PostTile.java:223) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at net.minecraftforge.common.extensions.IForgeBlockEntity.handleUpdateTag(IForgeBlockEntity.java:72) ~[forge-1.18.2-40.2.14-universal.jar%23201!/:?]
	at gollorum.signpost.minecraft.block.tiles.PostTile.handleUpdateTag(PostTile.java:305) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at net.minecraft.world.level.chunk.LevelChunk.m_187967_(LevelChunk.java:444) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.network.protocol.game.ClientboundLevelChunkPacketData.m_195674_(ClientboundLevelChunkPacketData.java:107) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.network.protocol.game.ClientboundLevelChunkPacketData.m_195660_(ClientboundLevelChunkPacketData.java:96) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.world.level.chunk.LevelChunk.m_187971_(LevelChunk.java:441) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.multiplayer.ClientChunkCache.m_194116_(ClientChunkCache.java:97) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.multiplayer.ClientPacketListener.m_194198_(ClientPacketListener.java:605) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.multiplayer.ClientPacketListener.m_183388_(ClientPacketListener.java:600) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket.m_5797_(ClientboundLevelChunkWithLightPacket.java:45) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket.m_5797_(ClientboundLevelChunkWithLightPacket.java:12) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.network.protocol.PacketUtils.m_131356_(PacketUtils.java:22) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.util.thread.BlockableEventLoop.m_6367_(BlockableEventLoop.java:157) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.util.thread.ReentrantBlockableEventLoop.m_6367_(ReentrantBlockableEventLoop.java:23) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.util.thread.BlockableEventLoop.m_7245_(BlockableEventLoop.java:131) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.util.thread.BlockableEventLoop.m_18699_(BlockableEventLoop.java:116) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.Minecraft.m_91383_(Minecraft.java:1015) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.Minecraft.m_91374_(Minecraft.java:665) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.main.Main.main(Main.java:205) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source) ~[?:?]
	at java.lang.reflect.Method.invoke(Unknown Source) ~[?:?]
	at net.minecraftforge.fml.loading.targets.CommonClientLaunchHandler.lambda$launchService$0(CommonClientLaunchHandler.java:31) ~[fmlloader-1.18.2-40.2.14.jar%2318!/:?]
	at cpw.mods.modlauncher.LaunchServiceHandlerDecorator.launch(LaunchServiceHandlerDecorator.java:37) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:53) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:71) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.Launcher.run(Launcher.java:106) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.Launcher.main(Launcher.java:77) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:26) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:23) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.bootstraplauncher.BootstrapLauncher.main(BootstrapLauncher.java:149) [bootstraplauncher-1.0.0.jar:?]
[01:44:31] [Render thread/WARN]: Received passengers for unknown entity
[01:44:31] [Render thread/WARN]: Received passengers for unknown entity
[01:44:31] [Render thread/ERROR]: Error executing task on Client
java.lang.NullPointerException: Cannot invoke "gollorum.signpost.blockpartdata.types.renderers.BlockPartWaystoneUpdateListener.addListener(gollorum.signpost.utils.BlockPart, java.util.function.BiConsumer)" because the return value of "gollorum.signpost.blockpartdata.types.renderers.BlockPartWaystoneUpdateListener.getInstance()" is null
	at gollorum.signpost.blockpartdata.types.SignBlockPart.attachTo(SignBlockPart.java:195) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at gollorum.signpost.minecraft.block.tiles.PostTile.addPart(PostTile.java:124) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at gollorum.signpost.minecraft.block.tiles.PostTile.addPart(PostTile.java:120) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at gollorum.signpost.minecraft.block.tiles.PostTile.readParts(PostTile.java:252) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at gollorum.signpost.minecraft.block.tiles.PostTile.readSelf(PostTile.java:267) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at gollorum.signpost.minecraft.block.tiles.PostTile.m_142466_(PostTile.java:223) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at net.minecraftforge.common.extensions.IForgeBlockEntity.handleUpdateTag(IForgeBlockEntity.java:72) ~[forge-1.18.2-40.2.14-universal.jar%23201!/:?]
	at gollorum.signpost.minecraft.block.tiles.PostTile.handleUpdateTag(PostTile.java:305) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at net.minecraft.world.level.chunk.LevelChunk.m_187967_(LevelChunk.java:444) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.network.protocol.game.ClientboundLevelChunkPacketData.m_195674_(ClientboundLevelChunkPacketData.java:107) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.network.protocol.game.ClientboundLevelChunkPacketData.m_195660_(ClientboundLevelChunkPacketData.java:96) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.world.level.chunk.LevelChunk.m_187971_(LevelChunk.java:441) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.multiplayer.ClientChunkCache.m_194116_(ClientChunkCache.java:97) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.multiplayer.ClientPacketListener.m_194198_(ClientPacketListener.java:605) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.multiplayer.ClientPacketListener.m_183388_(ClientPacketListener.java:600) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket.m_5797_(ClientboundLevelChunkWithLightPacket.java:45) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket.m_5797_(ClientboundLevelChunkWithLightPacket.java:12) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.network.protocol.PacketUtils.m_131356_(PacketUtils.java:22) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.util.thread.BlockableEventLoop.m_6367_(BlockableEventLoop.java:157) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.util.thread.ReentrantBlockableEventLoop.m_6367_(ReentrantBlockableEventLoop.java:23) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.util.thread.BlockableEventLoop.m_7245_(BlockableEventLoop.java:131) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.util.thread.BlockableEventLoop.m_18699_(BlockableEventLoop.java:116) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.Minecraft.m_91383_(Minecraft.java:1015) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.Minecraft.m_91374_(Minecraft.java:665) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.main.Main.main(Main.java:205) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source) ~[?:?]
	at java.lang.reflect.Method.invoke(Unknown Source) ~[?:?]
	at net.minecraftforge.fml.loading.targets.CommonClientLaunchHandler.lambda$launchService$0(CommonClientLaunchHandler.java:31) ~[fmlloader-1.18.2-40.2.14.jar%2318!/:?]
	at cpw.mods.modlauncher.LaunchServiceHandlerDecorator.launch(LaunchServiceHandlerDecorator.java:37) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:53) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:71) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.Launcher.run(Launcher.java:106) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.Launcher.main(Launcher.java:77) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:26) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:23) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.bootstraplauncher.BootstrapLauncher.main(BootstrapLauncher.java:149) [bootstraplauncher-1.0.0.jar:?]
[01:44:31] [Render thread/ERROR]: Error executing task on Client
java.lang.NullPointerException: Cannot invoke "gollorum.signpost.blockpartdata.types.renderers.BlockPartWaystoneUpdateListener.addListener(gollorum.signpost.utils.BlockPart, java.util.function.BiConsumer)" because the return value of "gollorum.signpost.blockpartdata.types.renderers.BlockPartWaystoneUpdateListener.getInstance()" is null
	at gollorum.signpost.blockpartdata.types.SignBlockPart.attachTo(SignBlockPart.java:195) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at gollorum.signpost.minecraft.block.tiles.PostTile.addPart(PostTile.java:124) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at gollorum.signpost.minecraft.block.tiles.PostTile.addPart(PostTile.java:120) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at gollorum.signpost.minecraft.block.tiles.PostTile.readParts(PostTile.java:252) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at gollorum.signpost.minecraft.block.tiles.PostTile.readSelf(PostTile.java:267) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at gollorum.signpost.minecraft.block.tiles.PostTile.m_142466_(PostTile.java:223) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at net.minecraftforge.common.extensions.IForgeBlockEntity.handleUpdateTag(IForgeBlockEntity.java:72) ~[forge-1.18.2-40.2.14-universal.jar%23201!/:?]
	at gollorum.signpost.minecraft.block.tiles.PostTile.handleUpdateTag(PostTile.java:305) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at net.minecraft.world.level.chunk.LevelChunk.m_187967_(LevelChunk.java:444) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.network.protocol.game.ClientboundLevelChunkPacketData.m_195674_(ClientboundLevelChunkPacketData.java:107) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.network.protocol.game.ClientboundLevelChunkPacketData.m_195660_(ClientboundLevelChunkPacketData.java:96) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.world.level.chunk.LevelChunk.m_187971_(LevelChunk.java:441) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.multiplayer.ClientChunkCache.m_194116_(ClientChunkCache.java:97) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.multiplayer.ClientPacketListener.m_194198_(ClientPacketListener.java:605) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.multiplayer.ClientPacketListener.m_183388_(ClientPacketListener.java:600) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket.m_5797_(ClientboundLevelChunkWithLightPacket.java:45) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket.m_5797_(ClientboundLevelChunkWithLightPacket.java:12) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.network.protocol.PacketUtils.m_131356_(PacketUtils.java:22) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.util.thread.BlockableEventLoop.m_6367_(BlockableEventLoop.java:157) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.util.thread.ReentrantBlockableEventLoop.m_6367_(ReentrantBlockableEventLoop.java:23) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.util.thread.BlockableEventLoop.m_7245_(BlockableEventLoop.java:131) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.util.thread.BlockableEventLoop.m_18699_(BlockableEventLoop.java:116) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.Minecraft.m_91383_(Minecraft.java:1015) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.Minecraft.m_91374_(Minecraft.java:665) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.main.Main.main(Main.java:205) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source) ~[?:?]
	at java.lang.reflect.Method.invoke(Unknown Source) ~[?:?]
	at net.minecraftforge.fml.loading.targets.CommonClientLaunchHandler.lambda$launchService$0(CommonClientLaunchHandler.java:31) ~[fmlloader-1.18.2-40.2.14.jar%2318!/:?]
	at cpw.mods.modlauncher.LaunchServiceHandlerDecorator.launch(LaunchServiceHandlerDecorator.java:37) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:53) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:71) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.Launcher.run(Launcher.java:106) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.Launcher.main(Launcher.java:77) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:26) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:23) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.bootstraplauncher.BootstrapLauncher.main(BootstrapLauncher.java:149) [bootstraplauncher-1.0.0.jar:?]
[01:44:31] [Render thread/ERROR]: Error executing task on Client
java.lang.NullPointerException: Cannot invoke "gollorum.signpost.blockpartdata.types.renderers.BlockPartWaystoneUpdateListener.addListener(gollorum.signpost.utils.BlockPart, java.util.function.BiConsumer)" because the return value of "gollorum.signpost.blockpartdata.types.renderers.BlockPartWaystoneUpdateListener.getInstance()" is null
	at gollorum.signpost.blockpartdata.types.SignBlockPart.attachTo(SignBlockPart.java:195) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at gollorum.signpost.minecraft.block.tiles.PostTile.addPart(PostTile.java:124) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at gollorum.signpost.minecraft.block.tiles.PostTile.addPart(PostTile.java:120) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at gollorum.signpost.minecraft.block.tiles.PostTile.readParts(PostTile.java:252) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at gollorum.signpost.minecraft.block.tiles.PostTile.readSelf(PostTile.java:267) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at gollorum.signpost.minecraft.block.tiles.PostTile.m_142466_(PostTile.java:223) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at net.minecraftforge.common.extensions.IForgeBlockEntity.handleUpdateTag(IForgeBlockEntity.java:72) ~[forge-1.18.2-40.2.14-universal.jar%23201!/:?]
	at gollorum.signpost.minecraft.block.tiles.PostTile.handleUpdateTag(PostTile.java:305) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at net.minecraft.world.level.chunk.LevelChunk.m_187967_(LevelChunk.java:444) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.network.protocol.game.ClientboundLevelChunkPacketData.m_195674_(ClientboundLevelChunkPacketData.java:107) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.network.protocol.game.ClientboundLevelChunkPacketData.m_195660_(ClientboundLevelChunkPacketData.java:96) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.world.level.chunk.LevelChunk.m_187971_(LevelChunk.java:441) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.multiplayer.ClientChunkCache.m_194116_(ClientChunkCache.java:97) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.multiplayer.ClientPacketListener.m_194198_(ClientPacketListener.java:605) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.multiplayer.ClientPacketListener.m_183388_(ClientPacketListener.java:600) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket.m_5797_(ClientboundLevelChunkWithLightPacket.java:45) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket.m_5797_(ClientboundLevelChunkWithLightPacket.java:12) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.network.protocol.PacketUtils.m_131356_(PacketUtils.java:22) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.util.thread.BlockableEventLoop.m_6367_(BlockableEventLoop.java:157) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.util.thread.ReentrantBlockableEventLoop.m_6367_(ReentrantBlockableEventLoop.java:23) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.util.thread.BlockableEventLoop.m_7245_(BlockableEventLoop.java:131) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.util.thread.BlockableEventLoop.m_18699_(BlockableEventLoop.java:116) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.Minecraft.m_91383_(Minecraft.java:1015) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.Minecraft.m_91374_(Minecraft.java:665) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.main.Main.main(Main.java:205) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source) ~[?:?]
	at java.lang.reflect.Method.invoke(Unknown Source) ~[?:?]
	at net.minecraftforge.fml.loading.targets.CommonClientLaunchHandler.lambda$launchService$0(CommonClientLaunchHandler.java:31) ~[fmlloader-1.18.2-40.2.14.jar%2318!/:?]
	at cpw.mods.modlauncher.LaunchServiceHandlerDecorator.launch(LaunchServiceHandlerDecorator.java:37) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:53) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:71) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.Launcher.run(Launcher.java:106) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.Launcher.main(Launcher.java:77) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:26) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:23) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.bootstraplauncher.BootstrapLauncher.main(BootstrapLauncher.java:149) [bootstraplauncher-1.0.0.jar:?]
[01:44:31] [Render thread/WARN]: Received passengers for unknown entity
[01:44:31] [Render thread/WARN]: Received passengers for unknown entity
[01:44:31] [Render thread/ERROR]: Error executing task on Client
java.lang.NullPointerException: Cannot invoke "gollorum.signpost.blockpartdata.types.renderers.BlockPartWaystoneUpdateListener.addListener(gollorum.signpost.utils.BlockPart, java.util.function.BiConsumer)" because the return value of "gollorum.signpost.blockpartdata.types.renderers.BlockPartWaystoneUpdateListener.getInstance()" is null
	at gollorum.signpost.blockpartdata.types.SignBlockPart.attachTo(SignBlockPart.java:195) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at gollorum.signpost.minecraft.block.tiles.PostTile.addPart(PostTile.java:124) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at gollorum.signpost.minecraft.block.tiles.PostTile.addPart(PostTile.java:120) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at gollorum.signpost.minecraft.block.tiles.PostTile.readParts(PostTile.java:252) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at gollorum.signpost.minecraft.block.tiles.PostTile.readSelf(PostTile.java:267) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at gollorum.signpost.minecraft.block.tiles.PostTile.m_142466_(PostTile.java:223) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at net.minecraftforge.common.extensions.IForgeBlockEntity.handleUpdateTag(IForgeBlockEntity.java:72) ~[forge-1.18.2-40.2.14-universal.jar%23201!/:?]
	at gollorum.signpost.minecraft.block.tiles.PostTile.handleUpdateTag(PostTile.java:305) ~[signpost-1.18.2-2.02.0.jar%23168!/:1.18.2-2.02.0]
	at net.minecraft.world.level.chunk.LevelChunk.m_187967_(LevelChunk.java:444) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.network.protocol.game.ClientboundLevelChunkPacketData.m_195674_(ClientboundLevelChunkPacketData.java:107) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.network.protocol.game.ClientboundLevelChunkPacketData.m_195660_(ClientboundLevelChunkPacketData.java:96) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.world.level.chunk.LevelChunk.m_187971_(LevelChunk.java:441) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.multiplayer.ClientChunkCache.m_194116_(ClientChunkCache.java:97) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.multiplayer.ClientPacketListener.m_194198_(ClientPacketListener.java:605) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.multiplayer.ClientPacketListener.m_183388_(ClientPacketListener.java:600) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket.m_5797_(ClientboundLevelChunkWithLightPacket.java:45) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket.m_5797_(ClientboundLevelChunkWithLightPacket.java:12) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.network.protocol.PacketUtils.m_131356_(PacketUtils.java:22) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.util.thread.BlockableEventLoop.m_6367_(BlockableEventLoop.java:157) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.util.thread.ReentrantBlockableEventLoop.m_6367_(ReentrantBlockableEventLoop.java:23) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.util.thread.BlockableEventLoop.m_7245_(BlockableEventLoop.java:131) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.util.thread.BlockableEventLoop.m_18699_(BlockableEventLoop.java:116) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.Minecraft.m_91383_(Minecraft.java:1015) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.Minecraft.m_91374_(Minecraft.java:665) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at net.minecraft.client.main.Main.main(Main.java:205) ~[client-1.18.2-20220404.173914-srg.jar%23196!/:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source) ~[?:?]
	at java.lang.reflect.Method.invoke(Unknown Source) ~[?:?]
	at net.minecraftforge.fml.loading.targets.CommonClientLaunchHandler.lambda$launchService$0(CommonClientLaunchHandler.java:31) ~[fmlloader-1.18.2-40.2.14.jar%2318!/:?]
	at cpw.mods.modlauncher.LaunchServiceHandlerDecorator.launch(LaunchServiceHandlerDecorator.java:37) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:53) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:71) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.Launcher.run(Launcher.java:106) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.Launcher.main(Launcher.java:77) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:26) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:23) [modlauncher-9.1.3.jar%235!/:?]
	at cpw.mods.bootstraplauncher.BootstrapLauncher.main(BootstrapLauncher.java:149) [bootstraplauncher-1.0.0.jar:?]
```
